### PR TITLE
ImportError instead of ModuleNotFoundError

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ def get_long_description():
     try:
         import pypandoc
         long_description = pypandoc.convert('README.md', 'rst')
-    except ModuleNotFoundError:
+    except ImportError:
         long_description = open('README.md').read()
     return long_description
 


### PR DESCRIPTION
ModuleNotFoundError is new in python 3.6. Replacing it with its superclass so older python versions could be supported.