### PR TITLE
Support 32-bit Python on 64-bit hosts

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -31,7 +31,12 @@ jobs:
     strategy:
       matrix:
         python-version: [3.6, 3.7, 3.8, 3.9]
+        python-arch: [x64]
         os: [ubuntu-latest, windows-latest]
+        include:
+          - python-version: 3.6
+            python-arch: x86
+            os: windows-latest
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
@@ -44,6 +49,7 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
+          architecture: ${{ matrix.python-arch }}
       - name: Install the package
         run: |
           pip3 install dist/webp-*.tar.gz

--- a/README.md
+++ b/README.md
@@ -133,3 +133,5 @@ $ twine upload dist/webp-*-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
   resulting in a single frame. Unfortunately, WebP seems to discard timestamp
   information in this case, which breaks `webp.load_images` when the FPS
   is specified.
+* There are currently no 32-bit binaries of libwebp uploaded to Conan Center. If you are running
+  32-bit Python, libwebp will be built from source.

--- a/webp_build/builder.py
+++ b/webp_build/builder.py
@@ -13,7 +13,12 @@ conan, _, _ = conan_api.ConanAPIV1.factory()
 
 # Use Conan to install libwebp
 with tempfile.TemporaryDirectory() as tmp_dir:
-    conan.install(path=getcwd(), cwd=tmp_dir)
+    settings = []
+    print(f'platform.architecture: {platform.architecture()}')
+    print(f'platform.machine: {platform.machine()}')
+    if platform.architecture()[0] == '32bit' and platform.machine().lower() in {'amd64', 'x86_64', 'x64'}:
+        settings.append('arch=x86')
+    conan.install(path=getcwd(), cwd=tmp_dir, settings=settings, build=['missing'])
     with open(path.join(tmp_dir, 'conanbuildinfo.json'), 'r') as f:
         conan_info = json.load(f)
 


### PR DESCRIPTION
Currently the host architecture is used by Conan to determine which libwebp binary to download. This means that if the user is running 32-bit Python, building the CFFI extension will fail during linking (see https://github.com/anibali/pywebp/issues/30).

Here we attempt to detect this scenario and pass a custom setting to Conan. Note that Conan Center currently does not have any 32-bit binaries of libwebp available, so it will be built from source.

## TODO

- [x] Set up CI for 32-bit Python on a 64-bit host to test that this works.