### PR TITLE
Fix macOS arm64 wheel building & Add wheel building for all architectures supported by cibuildwheel

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -99,6 +99,7 @@ jobs:
           CIBW_ARCHS_LINUX: ${{ matrix.cibw_archs_linux }}
           CIBW_ARCHS_WINDOWS: ${{ matrix.cibw_archs_windows }}
           CIBW_ARCHS_MACOS: ${{ matrix.cibw_archs_macos }}
+          CIBW_SKIP: "pp37-* pp38-*" # Pillow unsupported on pypy<3.9
           CIBW_TEST_SKIP: "*_arm64 *_universal2:arm64"  # TODO: Use arm64 CI runner when available
           CIBW_PROJECT_REQUIRES_PYTHON: '>=3.8,<3.12'
           CIBW_TEST_REQUIRES: pytest

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -62,10 +62,22 @@ jobs:
             cibw_archs_linux: i686
           - os: ubuntu-20.04
             cibw_archs_linux: aarch64
+            cibw_build: "*-muslinux_*"
+          - os: ubuntu-20.04
+            cibw_archs_linux: aarch64
+            cibw_build: "*-manylinux_*"
           - os: ubuntu-20.04
             cibw_archs_linux: ppc64le
+            cibw_build: "*-muslinux_*"
+          - os: ubuntu-20.04
+            cibw_archs_linux: ppc64le
+            cibw_build: "*-manylinux_*"
           - os: ubuntu-20.04
             cibw_archs_linux: s390x
+            cibw_build: "*-muslinux_*"
+          - os: ubuntu-20.04
+            cibw_archs_linux: s390x
+            cibw_build: "*-manylinux_*"
           - os: windows-2019
             cibw_archs_windows: AMD64
           - os: windows-2019
@@ -99,13 +111,12 @@ jobs:
           CIBW_ARCHS_LINUX: ${{ matrix.cibw_archs_linux }}
           CIBW_ARCHS_WINDOWS: ${{ matrix.cibw_archs_windows }}
           CIBW_ARCHS_MACOS: ${{ matrix.cibw_archs_macos }}
-          CIBW_SKIP: "*-muslinux_*"
           # TODO: Use arm64 CI runner when available
           # Skip test for platforms that cannot install dependencies
           # Pillow: i686, pypy<3.9
           # numpy: cp38-musllinux-*
           # Technically can use on platforms that cannot install dependencies (Users has to compile dependencies themselves)
-          CIBW_TEST_SKIP: "*_arm64 *_universal2:arm64 *-win32 *_i686 pp{37,38}-*"
+          CIBW_TEST_SKIP: "*_arm64 *_universal2:arm64 *-win32 *_i686 pp{37,38}-* cp{36,37,38}-musllinux_*"
           CIBW_PROJECT_REQUIRES_PYTHON: '>=3.8,<3.12'
           CIBW_TEST_REQUIRES: pytest
           CIBW_TEST_COMMAND: pytest {package}/tests

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -62,19 +62,19 @@ jobs:
             cibw_archs_linux: i686
           - os: ubuntu-20.04
             cibw_archs_linux: aarch64
-            cibw_build: "*-muslinux_*"
+            cibw_build: "*-musllinux_*"
           - os: ubuntu-20.04
             cibw_archs_linux: aarch64
             cibw_build: "*-manylinux_*"
           - os: ubuntu-20.04
             cibw_archs_linux: ppc64le
-            cibw_build: "*-muslinux_*"
+            cibw_build: "*-musllinux_*"
           - os: ubuntu-20.04
             cibw_archs_linux: ppc64le
             cibw_build: "*-manylinux_*"
           - os: ubuntu-20.04
             cibw_archs_linux: s390x
-            cibw_build: "*-muslinux_*"
+            cibw_build: "*-musllinux_*"
           - os: ubuntu-20.04
             cibw_archs_linux: s390x
             cibw_build: "*-manylinux_*"

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -62,22 +62,10 @@ jobs:
             cibw_archs_linux: i686
           - os: ubuntu-20.04
             cibw_archs_linux: aarch64
-            cibw_skip: "*-muslinux_*"
-          - os: ubuntu-20.04
-            cibw_archs_linux: aarch64
-            cibw_skip: "*-manylinux_*"
           - os: ubuntu-20.04
             cibw_archs_linux: ppc64le
-            cibw_skip: "*-muslinux_*"
-          - os: ubuntu-20.04
-            cibw_archs_linux: ppc64le
-            cibw_skip: "*-manylinux_*"
           - os: ubuntu-20.04
             cibw_archs_linux: s390x
-            cibw_skip: "*-muslinux_*"
-          - os: ubuntu-20.04
-            cibw_archs_linux: s390x
-            cibw_skip: "*-manylinux_*"
           - os: windows-2019
             cibw_archs_windows: AMD64
           - os: windows-2019
@@ -111,13 +99,13 @@ jobs:
           CIBW_ARCHS_LINUX: ${{ matrix.cibw_archs_linux }}
           CIBW_ARCHS_WINDOWS: ${{ matrix.cibw_archs_windows }}
           CIBW_ARCHS_MACOS: ${{ matrix.cibw_archs_macos }}
-          CIBW_SKIP: ${{ matrix.cibw_skip }}
+          CIBW_SKIP: "*-muslinux_*"
           # TODO: Use arm64 CI runner when available
           # Skip test for platforms that cannot install dependencies
           # Pillow: i686, pypy<3.9
           # numpy: cp38-musllinux-*
           # Technically can use on platforms that cannot install dependencies (Users has to compile dependencies themselves)
-          CIBW_TEST_SKIP: "*_arm64 *_universal2:arm64 *-win32 *_i686 pp{37,38}-* cp{36,37,38}-musllinux_*"
+          CIBW_TEST_SKIP: "*_arm64 *_universal2:arm64 *-win32 *_i686 pp{37,38}-*"
           CIBW_PROJECT_REQUIRES_PYTHON: '>=3.8,<3.12'
           CIBW_TEST_REQUIRES: pytest
           CIBW_TEST_COMMAND: pytest {package}/tests

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -78,9 +78,10 @@ jobs:
           package-dir: webp.tar.gz
           output-dir: dist
         env:
+          CIBW_BUILD_FRONTEND: build
           CIBW_BUILD: ${{ matrix.cibw_build }}
           CIBW_ARCHS_MACOS: ${{ matrix.cibw_archs_macos }}  # Enable cross-compilation on macOS
-          # CIBW_TEST_SKIP: '*-macosx_universal2:arm64'  # TODO: Use arm64 CI runner when available
+          CIBW_TEST_SKIP: "*_arm64 *_universal2:arm64"  # TODO: Use arm64 CI runner when available
           CIBW_PROJECT_REQUIRES_PYTHON: '>=3.8,<3.12'
           CIBW_TEST_REQUIRES: pytest
           CIBW_TEST_COMMAND: pytest {package}/tests

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -62,10 +62,22 @@ jobs:
             cibw_archs_linux: i686
           - os: ubuntu-20.04
             cibw_archs_linux: aarch64
+            cibw_skip: "*-muslinux_*"
+          - os: ubuntu-20.04
+            cibw_archs_linux: aarch64
+            cibw_skip: "*-manylinux_*"
           - os: ubuntu-20.04
             cibw_archs_linux: ppc64le
+            cibw_skip: "*-muslinux_*"
+          - os: ubuntu-20.04
+            cibw_archs_linux: ppc64le
+            cibw_skip: "*-manylinux_*"
           - os: ubuntu-20.04
             cibw_archs_linux: s390x
+            cibw_skip: "*-muslinux_*"
+          - os: ubuntu-20.04
+            cibw_archs_linux: s390x
+            cibw_skip: "*-manylinux_*"
           - os: windows-2019
             cibw_archs_windows: AMD64
           - os: windows-2019
@@ -99,10 +111,13 @@ jobs:
           CIBW_ARCHS_LINUX: ${{ matrix.cibw_archs_linux }}
           CIBW_ARCHS_WINDOWS: ${{ matrix.cibw_archs_windows }}
           CIBW_ARCHS_MACOS: ${{ matrix.cibw_archs_macos }}
+          CIBW_SKIP: ${{ matrix.cibw_skip }}
           # TODO: Use arm64 CI runner when available
-          # Skip test for platforms that cannot install Pillow: i686, pypy<3.9
-          # Technically can use on platforms that cannot install Pillow (Users has to compile Pillow themselves)
-          CIBW_TEST_SKIP: "*_arm64 *_universal2:arm64 *-win32 *_i686 pp37-* pp38-*"
+          # Skip test for platforms that cannot install dependencies
+          # Pillow: i686, pypy<3.9
+          # numpy: cp38-musllinux-*
+          # Technically can use on platforms that cannot install dependencies (Users has to compile dependencies themselves)
+          CIBW_TEST_SKIP: "*_arm64 *_universal2:arm64 *-win32 *_i686 pp{37,38}-* cp{36,37,38}-musllinux_*"
           CIBW_PROJECT_REQUIRES_PYTHON: '>=3.8,<3.12'
           CIBW_TEST_REQUIRES: pytest
           CIBW_TEST_COMMAND: pytest {package}/tests

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -58,26 +58,34 @@ jobs:
         include:
           - os: ubuntu-20.04
             cibw_archs_linux: x86_64
+            cibw_build: "*-manylinux_*"
+          - os: ubuntu-20.04
+            cibw_archs_linux: x86_64
+            cibw_build: "*-musllinux_*"
           - os: ubuntu-20.04
             cibw_archs_linux: i686
+            cibw_build: "*-manylinux_*"
           - os: ubuntu-20.04
-            cibw_archs_linux: aarch64
+            cibw_archs_linux: i686
             cibw_build: "*-musllinux_*"
           - os: ubuntu-20.04
             cibw_archs_linux: aarch64
             cibw_build: "*-manylinux_*"
           - os: ubuntu-20.04
-            cibw_archs_linux: ppc64le
+            cibw_archs_linux: aarch64
             cibw_build: "*-musllinux_*"
           - os: ubuntu-20.04
             cibw_archs_linux: ppc64le
             cibw_build: "*-manylinux_*"
           - os: ubuntu-20.04
-            cibw_archs_linux: s390x
+            cibw_archs_linux: ppc64le
             cibw_build: "*-musllinux_*"
           - os: ubuntu-20.04
             cibw_archs_linux: s390x
             cibw_build: "*-manylinux_*"
+          - os: ubuntu-20.04
+            cibw_archs_linux: s390x
+            cibw_build: "*-musllinux_*"
           - os: windows-2019
             cibw_archs_windows: AMD64
           - os: windows-2019

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -69,8 +69,8 @@ jobs:
           output-dir: dist
         env:
           CIBW_BUILD: 'cp3*-manylinux_x86_64 cp3*-win_amd64 cp3*-macosx_universal2'
-          CIBW_ARCHS_MACOS: 'universal2'  # Enable cross-compilation on macOS
-          CIBW_TEST_SKIP: '*-macosx_universal2:arm64'  # TODO: Use arm64 CI runner when available
+          CIBW_ARCHS_MACOS: 'x86_64 arm64'  # Enable cross-compilation on macOS
+          # CIBW_TEST_SKIP: '*-macosx_universal2:arm64'  # TODO: Use arm64 CI runner when available
           CIBW_PROJECT_REQUIRES_PYTHON: '>=3.8,<3.12'
           CIBW_TEST_REQUIRES: pytest
           CIBW_TEST_COMMAND: pytest {package}/tests

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -54,7 +54,17 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, windows-2019, macos-12]
+        include:
+          - os: ubuntu-20.04
+            cibw_build: cp3*-manylinux_x86_64
+          - os: windows-2019
+            cibw_build: cp3*-win_amd64
+          - os: macos-12
+            cibw_build: cp3*-macosx_x86_64
+            cibw_arch_macos: x86_64
+          - os: macos-12
+            cibw_build: cp3*-macosx_arm64
+            cibw_arch_macos: arm64
     steps:
       - name: Fetch source distribution
         uses: actions/download-artifact@v3
@@ -68,8 +78,8 @@ jobs:
           package-dir: webp.tar.gz
           output-dir: dist
         env:
-          CIBW_BUILD: 'cp3*-manylinux_x86_64 cp3*-win_amd64 cp3*-macosx_x86_64 cp3*-macosx_arm64'
-          CIBW_ARCHS_MACOS: 'x86_64 arm64'  # Enable cross-compilation on macOS
+          CIBW_BUILD: ${{ matrix.cibw_build }}
+          CIBW_ARCHS_MACOS: ${{ matrix.cibw_archs_macos }}  # Enable cross-compilation on macOS
           # CIBW_TEST_SKIP: '*-macosx_universal2:arm64'  # TODO: Use arm64 CI runner when available
           CIBW_PROJECT_REQUIRES_PYTHON: '>=3.8,<3.12'
           CIBW_TEST_REQUIRES: pytest

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -68,7 +68,7 @@ jobs:
           package-dir: webp.tar.gz
           output-dir: dist
         env:
-          CIBW_BUILD: 'cp3*-manylinux_x86_64 cp3*-win_amd64 cp3*-macosx_universal2'
+          CIBW_BUILD: 'cp3*-manylinux_x86_64 cp3*-win_amd64 cp3*-macosx_x86_64 cp3*-macosx_arm64'
           CIBW_ARCHS_MACOS: 'x86_64 arm64'  # Enable cross-compilation on macOS
           # CIBW_TEST_SKIP: '*-macosx_universal2:arm64'  # TODO: Use arm64 CI runner when available
           CIBW_PROJECT_REQUIRES_PYTHON: '>=3.8,<3.12'

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -59,10 +59,10 @@ jobs:
             cibw_build: cp3*-manylinux_x86_64
           - os: windows-2019
             cibw_build: cp3*-win_amd64
-          - os: macos-12
+          - os: macos-11
             cibw_build: cp3*-macosx_x86_64
             cibw_archs_macos: x86_64
-          - os: macos-12
+          - os: macos-11
             cibw_build: cp3*-macosx_arm64
             cibw_archs_macos: arm64
     steps:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -53,6 +53,7 @@ jobs:
     needs: build-sdist
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: ubuntu-20.04

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -61,10 +61,10 @@ jobs:
             cibw_build: cp3*-win_amd64
           - os: macos-12
             cibw_build: cp3*-macosx_x86_64
-            cibw_arch_macos: x86_64
+            cibw_archs_macos: x86_64
           - os: macos-12
             cibw_build: cp3*-macosx_arm64
-            cibw_arch_macos: arm64
+            cibw_archs_macos: arm64
     steps:
       - name: Fetch source distribution
         uses: actions/download-artifact@v3

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -56,14 +56,24 @@ jobs:
       matrix:
         include:
           - os: ubuntu-20.04
-            cibw_build: cp3*-manylinux_x86_64
+            cibw_archs_linux: x86_64
+          - os: ubuntu-20.04
+            cibw_archs_linux: i686
+          - os: ubuntu-20.04
+            cibw_archs_linux: aarch64
+          - os: ubuntu-20.04
+            cibw_archs_linux: ppc64le
+          - os: ubuntu-20.04
+            cibw_archs_linux: s390x
           - os: windows-2019
-            cibw_build: cp3*-win_amd64
+            cibw_archs_windows: AMD64
+          - os: windows-2019
+            cibw_archs_windows: x86
+          - os: windows-2019
+            cibw_archs_windows: ARM64
           - os: macos-11
-            cibw_build: cp3*-macosx_x86_64
             cibw_archs_macos: x86_64
           - os: macos-11
-            cibw_build: cp3*-macosx_arm64
             cibw_archs_macos: arm64
     steps:
       - name: Fetch source distribution
@@ -72,6 +82,11 @@ jobs:
           name: sdist-${{ github.sha }}
           path: dist/
       - run: mv dist/webp-*.tar.gz webp.tar.gz
+      - name: Set up QEMU
+        if: runner.os == 'Linux'
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: all
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.15.0
         with:
@@ -80,7 +95,9 @@ jobs:
         env:
           CIBW_BUILD_FRONTEND: build
           CIBW_BUILD: ${{ matrix.cibw_build }}
-          CIBW_ARCHS_MACOS: ${{ matrix.cibw_archs_macos }}  # Enable cross-compilation on macOS
+          CIBW_ARCHS_LINUX: ${{ matrix.cibw_archs_linux }}
+          CIBW_ARCHS_WINDOWS: ${{ matrix.cibw_archs_windows }}
+          CIBW_ARCHS_MACOS: ${{ matrix.cibw_archs_macos }}
           CIBW_TEST_SKIP: "*_arm64 *_universal2:arm64"  # TODO: Use arm64 CI runner when available
           CIBW_PROJECT_REQUIRES_PYTHON: '>=3.8,<3.12'
           CIBW_TEST_REQUIRES: pytest

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -99,8 +99,10 @@ jobs:
           CIBW_ARCHS_LINUX: ${{ matrix.cibw_archs_linux }}
           CIBW_ARCHS_WINDOWS: ${{ matrix.cibw_archs_windows }}
           CIBW_ARCHS_MACOS: ${{ matrix.cibw_archs_macos }}
-          CIBW_SKIP: "pp37-* pp38-*" # Pillow unsupported on pypy<3.9
-          CIBW_TEST_SKIP: "*_arm64 *_universal2:arm64"  # TODO: Use arm64 CI runner when available
+          # TODO: Use arm64 CI runner when available
+          # Skip test for platforms that cannot install Pillow: i686, pypy<3.9
+          # Technically can use on platforms that cannot install Pillow (Users has to compile Pillow themselves)
+          CIBW_TEST_SKIP: "*_arm64 *_universal2:arm64 *-win32 *_i686 pp37-* pp38-*"
           CIBW_PROJECT_REQUIRES_PYTHON: '>=3.8,<3.12'
           CIBW_TEST_REQUIRES: pytest
           CIBW_TEST_COMMAND: pytest {package}/tests

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,7 +1,6 @@
 include README.md
 include LICENSE
 include conanfile.txt
-include conan_profile
 include pyproject.toml
 
 graft webp_build

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,7 @@
 include README.md
 include LICENSE
 include conanfile.txt
+include conan_profile
 include pyproject.toml
 
 graft webp_build

--- a/conan_profile
+++ b/conan_profile
@@ -1,1 +1,0 @@
-include(default)

--- a/conan_profile
+++ b/conan_profile
@@ -1,0 +1,4 @@
+include(default)
+
+[tool_requires]
+cmake/[>=3.5]

--- a/conan_profile
+++ b/conan_profile
@@ -1,4 +1,1 @@
 include(default)
-
-[tool_requires]
-cmake/[>=3.5]

--- a/conan_profile
+++ b/conan_profile
@@ -1,4 +1,0 @@
-include(default)
-
-[tool_requires]
-cmake/[>=3.5]

--- a/webp_build/builder.py
+++ b/webp_build/builder.py
@@ -27,15 +27,9 @@ if getenv('CIBW_ARCHS_MACOS') == 'arm64':
 elif getenv('CIBW_ARCHS_WINDOWS') == 'ARM64':
     settings.append('os=Windows')
     settings.append('arch=armv8')
-if getenv('CIBW_ARCHS_LINUX') not in (None, 'x86_64', 'aarch64') or getenv('CIBW_ARCHS_WINDOWS') not in (None, 'AMD64'):
-    # Windows: Only x86_64 CMake works
-    # Linux: CMake binaries are only provided for x86_64 and armv8 architectures
-    build_pkgs = ['*']
-else:
-    build_pkgs = ['missing']
 
 with tempfile.TemporaryDirectory() as tmp_dir:
-    conan.install(path=getcwd(), cwd=tmp_dir, settings=settings, build=build_pkgs,
+    conan.install(path=getcwd(), cwd=tmp_dir, settings=settings, build=['missing'],
                   profile_names=[path.abspath('conan_profile')])
     with open(path.join(tmp_dir, 'conanbuildinfo.json'), 'r') as f:
         conan_info = json.load(f)

--- a/webp_build/builder.py
+++ b/webp_build/builder.py
@@ -18,7 +18,7 @@ with tempfile.TemporaryDirectory() as tmp_dir:
     print(f'platform.machine: {platform.machine()}')
     if platform.architecture()[0] == '32bit' and platform.machine().lower() in {'amd64', 'x86_64', 'x64'}:
         settings.append('arch=x86')
-    if 'arm64' in os.getenv('CIBW_ARCHS_MACOS'):
+    if os.getenv('CIBW_ARCHS_MACOS') == 'arm64':
         settings.append('arch=armv8')
     conan.install(path=getcwd(), cwd=tmp_dir, settings=settings, build=['missing'],
                   profile_names=[path.abspath('conan_profile')])

--- a/webp_build/builder.py
+++ b/webp_build/builder.py
@@ -2,7 +2,7 @@ import json
 import platform
 import tempfile
 from importlib.resources import read_text
-from os import path, getcwd
+from os import path, getcwd, environ
 
 from cffi import FFI
 from conans.client import conan_api
@@ -18,6 +18,8 @@ with tempfile.TemporaryDirectory() as tmp_dir:
     print(f'platform.machine: {platform.machine()}')
     if platform.architecture()[0] == '32bit' and platform.machine().lower() in {'amd64', 'x86_64', 'x64'}:
         settings.append('arch=x86')
+    if 'arm64' in os.getenv('CIBW_ARCHS_MACOS'):
+        settings.append('arch=armv8')
     conan.install(path=getcwd(), cwd=tmp_dir, settings=settings, build=['missing'],
                   profile_names=[path.abspath('conan_profile')])
     with open(path.join(tmp_dir, 'conanbuildinfo.json'), 'r') as f:

--- a/webp_build/builder.py
+++ b/webp_build/builder.py
@@ -27,9 +27,13 @@ if getenv('CIBW_ARCHS_MACOS') == 'arm64':
 elif getenv('CIBW_ARCHS_WINDOWS') == 'ARM64':
     settings.append('os=Windows')
     settings.append('arch=armv8')
+if 'musllinux' in getenv('CIBW_BUILD'):
+    build_policy = ['always']
+else:
+    build_policy = ['missing']
 
 with tempfile.TemporaryDirectory() as tmp_dir:
-    conan.install(path=getcwd(), cwd=tmp_dir, settings=settings, build=['missing'])
+    conan.install(path=getcwd(), cwd=tmp_dir, settings=settings, build=build_policy)
     with open(path.join(tmp_dir, 'conanbuildinfo.json'), 'r') as f:
         conan_info = json.load(f)
 

--- a/webp_build/builder.py
+++ b/webp_build/builder.py
@@ -48,7 +48,7 @@ for dep in conan_info['dependencies']:
         include_dirs.append(include_path)
 
 if getenv('CIBW_ARCHS_MACOS') == 'arm64':
-    extra_compile_args.append('-target=arm64-apple-macos11')
+    extra_compile_args.append('--target=arm64-apple-macos11')
 
 # Specify C sources to be built by CFFI
 ffibuilder = FFI()

--- a/webp_build/builder.py
+++ b/webp_build/builder.py
@@ -13,7 +13,6 @@ conan, _, _ = conan_api.ConanAPIV1.factory()
 
 # Use Conan to install libwebp
 settings = []
-build_pkgs = ['missing']
 print(f'platform.architecture: {platform.architecture()}')
 print(f'platform.machine: {platform.machine()}')
 if platform.architecture()[0] == '32bit' and platform.machine().lower() in {'amd64', 'x86_64', 'x64', 'i686'}:
@@ -28,10 +27,12 @@ if getenv('CIBW_ARCHS_MACOS') == 'arm64':
 elif getenv('CIBW_ARCHS_WINDOWS') == 'ARM64':
     settings.append('os=Windows')
     settings.append('arch=armv8')
-elif getenv('CIBW_ARCHS_LINUX') not in (None, 'x86_64', 'aarch64') or getenv('CIBW_ARCHS_WINDOWS') not in (None, 'AMD64'):
-    # Windows: Only x86_64 works
+if getenv('CIBW_ARCHS_LINUX') not in (None, 'x86_64', 'aarch64') or getenv('CIBW_ARCHS_WINDOWS') not in (None, 'AMD64'):
+    # Windows: Only x86_64 CMake works
     # Linux: CMake binaries are only provided for x86_64 and armv8 architectures
-    build_pkgs.append('cmake')
+    build_pkgs = ['*']
+else:
+    build_pkgs = ['missing']
 
 with tempfile.TemporaryDirectory() as tmp_dir:
     conan.install(path=getcwd(), cwd=tmp_dir, settings=settings, build=build_pkgs,

--- a/webp_build/builder.py
+++ b/webp_build/builder.py
@@ -24,6 +24,9 @@ if getenv('CIBW_ARCHS_MACOS') == 'arm64':
     settings.append('compiler=apple-clang')
     settings.append('compiler.version=11.0')
     settings.append('compiler.libcxx=libc++')
+elif getenv('CIBW_ARCHS_WINDOWS') == 'ARM64':
+    settings.append('os=Windows')
+    settings.append('arch=armv8')
 
 with tempfile.TemporaryDirectory() as tmp_dir:
     conan.install(path=getcwd(), cwd=tmp_dir, settings=settings, build=['missing'],

--- a/webp_build/builder.py
+++ b/webp_build/builder.py
@@ -29,8 +29,7 @@ elif getenv('CIBW_ARCHS_WINDOWS') == 'ARM64':
     settings.append('arch=armv8')
 
 with tempfile.TemporaryDirectory() as tmp_dir:
-    conan.install(path=getcwd(), cwd=tmp_dir, settings=settings, build=['missing'],
-                  profile_names=[path.abspath('conan_profile')])
+    conan.install(path=getcwd(), cwd=tmp_dir, settings=settings, build=['missing'])
     with open(path.join(tmp_dir, 'conanbuildinfo.json'), 'r') as f:
         conan_info = json.load(f)
 

--- a/webp_build/builder.py
+++ b/webp_build/builder.py
@@ -15,7 +15,7 @@ conan, _, _ = conan_api.ConanAPIV1.factory()
 settings = []
 print(f'platform.architecture: {platform.architecture()}')
 print(f'platform.machine: {platform.machine()}')
-if platform.architecture()[0] == '32bit' and platform.machine().lower() in {'amd64', 'x86_64', 'x64'}:
+if platform.architecture()[0] == '32bit' and platform.machine().lower() in {'amd64', 'x86_64', 'x64', 'i686'}:
     settings.append('arch=x86')
 if getenv('CIBW_ARCHS_MACOS') == 'arm64':
     # https://blog.conan.io/2021/09/21/m1.html

--- a/webp_build/builder.py
+++ b/webp_build/builder.py
@@ -13,6 +13,7 @@ conan, _, _ = conan_api.ConanAPIV1.factory()
 
 # Use Conan to install libwebp
 settings = []
+build_pkgs = ['missing']
 print(f'platform.architecture: {platform.architecture()}')
 print(f'platform.machine: {platform.machine()}')
 if platform.architecture()[0] == '32bit' and platform.machine().lower() in {'amd64', 'x86_64', 'x64', 'i686'}:
@@ -27,9 +28,13 @@ if getenv('CIBW_ARCHS_MACOS') == 'arm64':
 elif getenv('CIBW_ARCHS_WINDOWS') == 'ARM64':
     settings.append('os=Windows')
     settings.append('arch=armv8')
+elif getenv('CIBW_ARCHS_LINUX') not in (None, 'x86_64', 'aarch64') or getenv('CIBW_ARCHS_WINDOWS') not in (None, 'AMD64'):
+    # Windows: Only x86_64 works
+    # Linux: CMake binaries are only provided for x86_64 and armv8 architectures
+    build_pkgs.append('cmake')
 
 with tempfile.TemporaryDirectory() as tmp_dir:
-    conan.install(path=getcwd(), cwd=tmp_dir, settings=settings, build=['missing'],
+    conan.install(path=getcwd(), cwd=tmp_dir, settings=settings, build=build_pkgs,
                   profile_names=[path.abspath('conan_profile')])
     with open(path.join(tmp_dir, 'conanbuildinfo.json'), 'r') as f:
         conan_info = json.load(f)

--- a/webp_build/builder.py
+++ b/webp_build/builder.py
@@ -19,7 +19,8 @@ with tempfile.TemporaryDirectory() as tmp_dir:
     if platform.architecture()[0] == '32bit' and platform.machine().lower() in {'amd64', 'x86_64', 'x64'}:
         settings.append('arch=x86')
     if getenv('CIBW_ARCHS_MACOS') == 'arm64':
-        settings.append('arch=armv8')
+        settings.append('os=Macos')
+        settings.append('arch=armv8') # https://blog.conan.io/2021/09/21/m1.html
     conan.install(path=getcwd(), cwd=tmp_dir, settings=settings, build=['missing'],
                   profile_names=[path.abspath('conan_profile')])
     with open(path.join(tmp_dir, 'conanbuildinfo.json'), 'r') as f:

--- a/webp_build/builder.py
+++ b/webp_build/builder.py
@@ -27,13 +27,16 @@ if getenv('CIBW_ARCHS_MACOS') == 'arm64':
 elif getenv('CIBW_ARCHS_WINDOWS') == 'ARM64':
     settings.append('os=Windows')
     settings.append('arch=armv8')
-if getenv('CIBW_BUILD') and 'musllinux' in getenv('CIBW_BUILD'):
+if ((getenv('CIBW_BUILD') and 'musllinux' in getenv('CIBW_BUILD')) or
+    getenv('CIBW_ARCHS_LINUX') not in (None, 'x86_64', 'aarch64') or
+    getenv('CIBW_ARCHS_WINDOWS') not in (None, 'AMD64')):
     build_policy = ['always']
 else:
     build_policy = ['missing']
 
 with tempfile.TemporaryDirectory() as tmp_dir:
-    conan.install(path=getcwd(), cwd=tmp_dir, settings=settings, build=build_policy)
+    conan.install(path=getcwd(), cwd=tmp_dir, settings=settings, build=build_policy,
+                  profile_names=[path.abspath('conan_profile')])
     with open(path.join(tmp_dir, 'conanbuildinfo.json'), 'r') as f:
         conan_info = json.load(f)
 

--- a/webp_build/builder.py
+++ b/webp_build/builder.py
@@ -12,24 +12,27 @@ import webp_build
 conan, _, _ = conan_api.ConanAPIV1.factory()
 
 # Use Conan to install libwebp
+settings = []
+print(f'platform.architecture: {platform.architecture()}')
+print(f'platform.machine: {platform.machine()}')
+if platform.architecture()[0] == '32bit' and platform.machine().lower() in {'amd64', 'x86_64', 'x64'}:
+    settings.append('arch=x86')
+if getenv('CIBW_ARCHS_MACOS') == 'arm64':
+    # https://blog.conan.io/2021/09/21/m1.html
+    settings.append('os=Macos')
+    settings.append('arch=armv8')
+
 with tempfile.TemporaryDirectory() as tmp_dir:
-    settings = []
-    print(f'platform.architecture: {platform.architecture()}')
-    print(f'platform.machine: {platform.machine()}')
-    if platform.architecture()[0] == '32bit' and platform.machine().lower() in {'amd64', 'x86_64', 'x64'}:
-        settings.append('arch=x86')
-    if getenv('CIBW_ARCHS_MACOS') == 'arm64':
-        # https://blog.conan.io/2021/09/21/m1.html
-        settings.append('os=Macos')
-        settings.append('arch=armv8')
     conan.install(path=getcwd(), cwd=tmp_dir, settings=settings, build=['missing'],
                   profile_names=[path.abspath('conan_profile')])
     with open(path.join(tmp_dir, 'conanbuildinfo.json'), 'r') as f:
         conan_info = json.load(f)
 
+print(conan_info)
+
 # Find header files and libraries in libwebp
 extra_objects = []
-extra_compile_args = []
+# extra_compile_args = []
 include_dirs = []
 libraries = []
 for dep in conan_info['dependencies']:
@@ -48,8 +51,13 @@ for dep in conan_info['dependencies']:
         include_dirs.append(include_path)
 
 if getenv('CIBW_ARCHS_MACOS') == 'arm64':
-    extra_compile_args.append('-target')
-    extra_compile_args.append('arm64-apple-macos11')
+    extra_compile_args.append('--target=arm64-apple-macos11')
+
+print('CFFI arguments:')
+print(f'{extra_objects = }')
+print(f'{extra_compile_args = }')
+print(f'{include_dirs = }')
+print(f'{libraries = }')
 
 # Specify C sources to be built by CFFI
 ffibuilder = FFI()

--- a/webp_build/builder.py
+++ b/webp_build/builder.py
@@ -48,7 +48,7 @@ for dep in conan_info['dependencies']:
         include_dirs.append(include_path)
 
 if getenv('CIBW_ARCHS_MACOS') == 'arm64':
-    extra_compile_args.append('-target arm64-apple-macos11')
+    extra_compile_args.append('-target=arm64-apple-macos11')
 
 # Specify C sources to be built by CFFI
 ffibuilder = FFI()

--- a/webp_build/builder.py
+++ b/webp_build/builder.py
@@ -2,7 +2,7 @@ import json
 import platform
 import tempfile
 from importlib.resources import read_text
-from os import path, getcwd, environ
+from os import path, getcwd, getenv
 
 from cffi import FFI
 from conans.client import conan_api
@@ -18,7 +18,7 @@ with tempfile.TemporaryDirectory() as tmp_dir:
     print(f'platform.machine: {platform.machine()}')
     if platform.architecture()[0] == '32bit' and platform.machine().lower() in {'amd64', 'x86_64', 'x64'}:
         settings.append('arch=x86')
-    if os.getenv('CIBW_ARCHS_MACOS') == 'arm64':
+    if getenv('CIBW_ARCHS_MACOS') == 'arm64':
         settings.append('arch=armv8')
     conan.install(path=getcwd(), cwd=tmp_dir, settings=settings, build=['missing'],
                   profile_names=[path.abspath('conan_profile')])

--- a/webp_build/builder.py
+++ b/webp_build/builder.py
@@ -27,16 +27,13 @@ if getenv('CIBW_ARCHS_MACOS') == 'arm64':
 elif getenv('CIBW_ARCHS_WINDOWS') == 'ARM64':
     settings.append('os=Windows')
     settings.append('arch=armv8')
-if ((getenv('CIBW_BUILD') and 'musllinux' in getenv('CIBW_BUILD')) or
-    getenv('CIBW_ARCHS_LINUX') not in (None, 'x86_64', 'aarch64') or
-    getenv('CIBW_ARCHS_WINDOWS') not in (None, 'AMD64')):
+if getenv('CIBW_BUILD') and 'musllinux' in getenv('CIBW_BUILD'):
     build_policy = ['always']
 else:
     build_policy = ['missing']
 
 with tempfile.TemporaryDirectory() as tmp_dir:
-    conan.install(path=getcwd(), cwd=tmp_dir, settings=settings, build=build_policy,
-                  profile_names=[path.abspath('conan_profile')])
+    conan.install(path=getcwd(), cwd=tmp_dir, settings=settings, build=build_policy)
     with open(path.join(tmp_dir, 'conanbuildinfo.json'), 'r') as f:
         conan_info = json.load(f)
 

--- a/webp_build/builder.py
+++ b/webp_build/builder.py
@@ -32,7 +32,7 @@ print(conan_info)
 
 # Find header files and libraries in libwebp
 extra_objects = []
-# extra_compile_args = []
+extra_compile_args = []
 include_dirs = []
 libraries = []
 for dep in conan_info['dependencies']:

--- a/webp_build/builder.py
+++ b/webp_build/builder.py
@@ -48,7 +48,8 @@ for dep in conan_info['dependencies']:
         include_dirs.append(include_path)
 
 if getenv('CIBW_ARCHS_MACOS') == 'arm64':
-    extra_compile_args.append('--target=arm64-apple-macos11')
+    extra_compile_args.append('-target')
+    extra_compile_args.append('arm64-apple-macos11')
 
 # Specify C sources to be built by CFFI
 ffibuilder = FFI()

--- a/webp_build/builder.py
+++ b/webp_build/builder.py
@@ -21,6 +21,9 @@ if getenv('CIBW_ARCHS_MACOS') == 'arm64':
     # https://blog.conan.io/2021/09/21/m1.html
     settings.append('os=Macos')
     settings.append('arch=armv8')
+    settings.append('compiler=apple-clang')
+    settings.append('compiler.version=11.0')
+    settings.append('compiler.libcxx=libc++')
 
 with tempfile.TemporaryDirectory() as tmp_dir:
     conan.install(path=getcwd(), cwd=tmp_dir, settings=settings, build=['missing'],

--- a/webp_build/builder.py
+++ b/webp_build/builder.py
@@ -27,7 +27,7 @@ if getenv('CIBW_ARCHS_MACOS') == 'arm64':
 elif getenv('CIBW_ARCHS_WINDOWS') == 'ARM64':
     settings.append('os=Windows')
     settings.append('arch=armv8')
-if 'musllinux' in getenv('CIBW_BUILD'):
+if getenv('CIBW_BUILD') and 'musllinux' in getenv('CIBW_BUILD'):
     build_policy = ['always']
 else:
     build_policy = ['missing']


### PR DESCRIPTION
Fixes macOS arm64 wheel building (https://github.com/anibali/pywebp/issues/44)

Adds building:
- Windows x86, arm64
- Linux i686, aarch64, ppc64le, s390x
- musllinux