### PR TITLE
Reduce the number of wheels built

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -49,53 +49,55 @@ jobs:
           pytest tests/
 
   build-wheels:
-    name: Build and test wheels on ${{ matrix.os }}
+    name: Build ${{ matrix.os }} ${{ matrix.cibw_build }} wheels
     needs: build-sdist
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: false
       matrix:
         include:
           - os: ubuntu-20.04
             cibw_archs_linux: x86_64
-            cibw_build: "*-manylinux_*"
-          - os: ubuntu-20.04
-            cibw_archs_linux: x86_64
-            cibw_build: "*-musllinux_*"
-          - os: ubuntu-20.04
-            cibw_archs_linux: i686
-            cibw_build: "*-manylinux_*"
-          - os: ubuntu-20.04
-            cibw_archs_linux: i686
-            cibw_build: "*-musllinux_*"
-          - os: ubuntu-20.04
-            cibw_archs_linux: aarch64
-            cibw_build: "*-manylinux_*"
-          - os: ubuntu-20.04
-            cibw_archs_linux: aarch64
-            cibw_build: "*-musllinux_*"
-          - os: ubuntu-20.04
-            cibw_archs_linux: ppc64le
-            cibw_build: "*-manylinux_*"
-          - os: ubuntu-20.04
-            cibw_archs_linux: ppc64le
-            cibw_build: "*-musllinux_*"
-          - os: ubuntu-20.04
-            cibw_archs_linux: s390x
-            cibw_build: "*-manylinux_*"
-          - os: ubuntu-20.04
-            cibw_archs_linux: s390x
-            cibw_build: "*-musllinux_*"
+            cibw_build: "cp3*-manylinux_x86_64"
+#          - os: ubuntu-20.04
+#            cibw_archs_linux: x86_64
+#            cibw_build: "*-musllinux_*"
+#          - os: ubuntu-20.04
+#            cibw_archs_linux: i686
+#            cibw_build: "*-manylinux_*"
+#          - os: ubuntu-20.04
+#            cibw_archs_linux: i686
+#            cibw_build: "*-musllinux_*"
+#          - os: ubuntu-20.04
+#            cibw_archs_linux: aarch64
+#            cibw_build: "*-manylinux_*"
+#          - os: ubuntu-20.04
+#            cibw_archs_linux: aarch64
+#            cibw_build: "*-musllinux_*"
+#          - os: ubuntu-20.04
+#            cibw_archs_linux: ppc64le
+#            cibw_build: "*-manylinux_*"
+#          - os: ubuntu-20.04
+#            cibw_archs_linux: ppc64le
+#            cibw_build: "*-musllinux_*"
+#          - os: ubuntu-20.04
+#            cibw_archs_linux: s390x
+#            cibw_build: "*-manylinux_*"
+#          - os: ubuntu-20.04
+#            cibw_archs_linux: s390x
+#            cibw_build: "*-musllinux_*"
           - os: windows-2019
             cibw_archs_windows: AMD64
-          - os: windows-2019
-            cibw_archs_windows: x86
-          - os: windows-2019
-            cibw_archs_windows: ARM64
+            cibw_build: "cp3*-win_amd64"
+#          - os: windows-2019
+#            cibw_archs_windows: x86
+#          - os: windows-2019
+#            cibw_archs_windows: ARM64
           - os: macos-11
             cibw_archs_macos: x86_64
+            cibw_build: "cp3*-macosx_x86_64"
           - os: macos-11
             cibw_archs_macos: arm64
+            cibw_build: "cp3*-macosx_arm64"
     steps:
       - name: Fetch source distribution
         uses: actions/download-artifact@v3
@@ -103,11 +105,11 @@ jobs:
           name: sdist-${{ github.sha }}
           path: dist/
       - run: mv dist/webp-*.tar.gz webp.tar.gz
-      - name: Set up QEMU
-        if: runner.os == 'Linux'
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
+#      - name: Set up QEMU
+#        if: runner.os == 'Linux'
+#        uses: docker/setup-qemu-action@v2
+#        with:
+#          platforms: all
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.15.0
         with:
@@ -120,11 +122,7 @@ jobs:
           CIBW_ARCHS_WINDOWS: ${{ matrix.cibw_archs_windows }}
           CIBW_ARCHS_MACOS: ${{ matrix.cibw_archs_macos }}
           # TODO: Use arm64 CI runner when available
-          # Skip test for platforms that cannot install dependencies
-          # Pillow: i686, pypy<3.9
-          # numpy: cp38-musllinux-*
-          # Technically can use on platforms that cannot install dependencies (Users has to compile dependencies themselves)
-          CIBW_TEST_SKIP: "*_arm64 *_universal2:arm64 *-win32 *_i686 pp{37,38}-* cp{36,37,38}-musllinux_*"
+          CIBW_TEST_SKIP: "*_arm64"
           CIBW_PROJECT_REQUIRES_PYTHON: '>=3.8,<3.12'
           CIBW_TEST_REQUIRES: pytest
           CIBW_TEST_COMMAND: pytest {package}/tests

--- a/webp_build/builder.py
+++ b/webp_build/builder.py
@@ -13,8 +13,6 @@ conan, _, _ = conan_api.ConanAPIV1.factory()
 
 # Use Conan to install libwebp
 settings = []
-print(f'platform.architecture: {platform.architecture()}')
-print(f'platform.machine: {platform.machine()}')
 if platform.architecture()[0] == '32bit' and platform.machine().lower() in {'amd64', 'x86_64', 'x64', 'i686'}:
     settings.append('arch=x86')
 if getenv('CIBW_ARCHS_MACOS') == 'arm64':
@@ -36,8 +34,6 @@ with tempfile.TemporaryDirectory() as tmp_dir:
     conan.install(path=getcwd(), cwd=tmp_dir, settings=settings, build=build_policy)
     with open(path.join(tmp_dir, 'conanbuildinfo.json'), 'r') as f:
         conan_info = json.load(f)
-
-print(conan_info)
 
 # Find header files and libraries in libwebp
 extra_objects = []
@@ -61,12 +57,6 @@ for dep in conan_info['dependencies']:
 
 if getenv('CIBW_ARCHS_MACOS') == 'arm64':
     extra_compile_args.append('--target=arm64-apple-macos11')
-
-print('CFFI arguments:')
-print(f'{extra_objects = }')
-print(f'{extra_compile_args = }')
-print(f'{include_dirs = }')
-print(f'{libraries = }')
 
 # Specify C sources to be built by CFFI
 ffibuilder = FFI()


### PR DESCRIPTION
In the interest of keeping CI build times and making future maintenance manageable, I will limit builds to x86_64 (and arm64 for macOS). In the future it would be nice to enable musl builds (primarily for Alpine), but these do not seem to currently work.