### PR TITLE
Building universal2 wheel

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -98,6 +98,9 @@ jobs:
           - os: macos-11
             cibw_archs_macos: arm64
             cibw_build: "cp3*-macosx_arm64"
+          - os: macos-11
+            cibw_archs_macos: universal2
+            cibw_build: "cp3*-macosx_universal2"
     steps:
       - name: Fetch source distribution
         uses: actions/download-artifact@v3

--- a/webp_build/builder.py
+++ b/webp_build/builder.py
@@ -3,73 +3,102 @@ import platform
 import tempfile
 from importlib.resources import read_text
 from os import path, getcwd, getenv
+import platform
 
 from cffi import FFI
 from conans.client import conan_api
 
 import webp_build
 
-conan, _, _ = conan_api.ConanAPIV1.factory()
+def install_libwebp(arch=None):
+    # Use Conan to install libwebp
 
-# Use Conan to install libwebp
-settings = []
-if platform.architecture()[0] == '32bit' and platform.machine().lower() in {'amd64', 'x86_64', 'x64', 'i686'}:
-    settings.append('arch=x86')
-if getenv('CIBW_ARCHS_MACOS') == 'arm64':
-    # https://blog.conan.io/2021/09/21/m1.html
-    settings.append('os=Macos')
-    settings.append('arch=armv8')
-    settings.append('compiler=apple-clang')
-    settings.append('compiler.version=11.0')
-    settings.append('compiler.libcxx=libc++')
-elif getenv('CIBW_ARCHS_WINDOWS') == 'ARM64':
-    settings.append('os=Windows')
-    settings.append('arch=armv8')
-if getenv('CIBW_BUILD') and 'musllinux' in getenv('CIBW_BUILD'):
-    build_policy = ['always']
-else:
-    build_policy = ['missing']
+    conan, _, _ = conan_api.ConanAPIV1.factory()
 
-with tempfile.TemporaryDirectory() as tmp_dir:
-    conan.install(path=getcwd(), cwd=tmp_dir, settings=settings, build=build_policy)
-    with open(path.join(tmp_dir, 'conanbuildinfo.json'), 'r') as f:
-        conan_info = json.load(f)
+    settings = []
+    if platform.system() == 'Windows':
+        settings.append('os=Windows')
+    elif platform.system() == 'Darwin':
+        settings.append('os=Macos')
+        settings.append('compiler=apple-clang')
+        settings.append('compiler.version=11.0')
+        settings.append('compiler.libcxx=libc++')
+    elif platform.system() == 'Linux':
+        settings.append('os=Linux')
 
-# Find header files and libraries in libwebp
-extra_objects = []
-extra_compile_args = []
-include_dirs = []
-libraries = []
-for dep in conan_info['dependencies']:
-    for lib_name in dep['libs']:
-        if platform.system() == 'Windows':
-            lib_filename = '{}.lib'.format(lib_name)
-        else:
-            lib_filename = 'lib{}.a'.format(lib_name)
-        for lib_path in dep['lib_paths']:
-            candidate = path.join(lib_path, lib_filename)
-            if path.isfile(candidate):
-                extra_objects.append(candidate)
+    if arch:
+        settings.append(f'arch={arch}')
+
+    if getenv('CIBW_BUILD') and 'musllinux' in getenv('CIBW_BUILD'):
+        build_policy = ['always']
+    else:
+        build_policy = ['missing']
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        conan.install(path=getcwd(), cwd=tmp_dir, settings=settings, build=build_policy)
+        with open(path.join(tmp_dir, 'conanbuildinfo.json'), 'r') as f:
+            conan_info = json.load(f)
+    
+    return conan_info
+
+def fetch_cffi_settings(conan_info, cffi_settings):
+    # Find header files and libraries in libwebp
+
+    for dep in conan_info['dependencies']:
+        for lib_name in dep['libs']:
+            if platform.system() == 'Windows':
+                lib_filename = '{}.lib'.format(lib_name)
             else:
-                libraries.append(lib_name)
-    for include_path in dep['include_paths']:
-        include_dirs.append(include_path)
+                lib_filename = 'lib{}.a'.format(lib_name)
+            for lib_path in dep['lib_paths']:
+                candidate = path.join(lib_path, lib_filename)
+                if path.isfile(candidate):
+                    cffi_settings['extra_objects'].append(candidate)
+                else:
+                    cffi_settings['libraries'].append(lib_name)
+        for include_path in dep['include_paths']:
+            cffi_settings['include_dirs'].append(include_path)
+    
+    if  platform.system() == 'Darwin':
+        cffi_settings['extra_compile_args'].append('-mmacosx-version-min=11.0')
+    
+    return cffi_settings
 
-if getenv('CIBW_ARCHS_MACOS') == 'arm64':
-    extra_compile_args.append('--target=arm64-apple-macos11')
+def main():
+    if platform.architecture()[0] == '32bit' and platform.machine().lower() in {'amd64', 'x86_64', 'x64', 'i686'}:
+        arch = 'x86'
+    elif 'arm64' in getenv('CIBW_ARCHS_MACOS') or 'universal2' in getenv('CIBW_ARCHS_MACOS'):
+        arch = 'armv8'
+    elif 'ARM64' in getenv('CIBW_ARCHS_WINDOWS'):
+        arch = 'armv8'
 
-# Specify C sources to be built by CFFI
-ffibuilder = FFI()
-ffibuilder.set_source(
-    '_webp',
-    read_text(webp_build, 'source.c'),
-    extra_objects=extra_objects,
-    extra_compile_args=extra_compile_args,
-    include_dirs=include_dirs,
-    libraries=libraries,
-)
-ffibuilder.cdef(read_text(webp_build, 'cdef.h'))
+    cffi_settings = {
+        'extra_objects': [],
+        'extra_compile_args': [],
+        'include_dirs': [],
+        'libraries': []
+    }
 
+    conan_info = install_libwebp(arch)
+    cffi_settings = fetch_cffi_settings(conan_info, cffi_settings)
+    if 'universal2' in getenv('CIBW_ARCHS_MACOS'):
+        # Repeat to install the other architecture version of libwebp
+        conan_info = install_libwebp('x86_64')
+        cffi_settings = fetch_cffi_settings(conan_info, cffi_settings)
+
+    # Specify C sources to be built by CFFI
+    ffibuilder = FFI()
+    ffibuilder.set_source(
+        '_webp',
+        read_text(webp_build, 'source.c'),
+        extra_objects=cffi_settings['extra_objects'],
+        extra_compile_args=cffi_settings['extra_compile_args'],
+        include_dirs=cffi_settings['include_dirs'],
+        libraries=cffi_settings['libraries'],
+    )
+    ffibuilder.cdef(read_text(webp_build, 'cdef.h'))
+
+    ffibuilder.compile(verbose=True)
 
 if __name__ == '__main__':
-    ffibuilder.compile(verbose=True)
+    main()

--- a/webp_build/builder.py
+++ b/webp_build/builder.py
@@ -81,7 +81,7 @@ cffi_settings = {
 
 conan_info = install_libwebp(arch)
 cffi_settings = fetch_cffi_settings(conan_info, cffi_settings)
-if 'universal2' in getenv('CIBW_ARCHS_MACOS'):
+if getenv('CIBW_ARCHS_MACOS') and 'universal2' in getenv('CIBW_ARCHS_MACOS'):
     # Repeat to install the other architecture version of libwebp
     conan_info = install_libwebp('x86_64')
     cffi_settings = fetch_cffi_settings(conan_info, cffi_settings)

--- a/webp_build/builder.py
+++ b/webp_build/builder.py
@@ -64,6 +64,7 @@ def fetch_cffi_settings(conan_info, cffi_settings):
     
     return cffi_settings
 
+arch = None
 if platform.architecture()[0] == '32bit' and platform.machine().lower() in {'amd64', 'x86_64', 'x64', 'i686'}:
     arch = 'x86'
 elif getenv('CIBW_ARCHS_MACOS') and ('arm64' in getenv('CIBW_ARCHS_MACOS') or 'universal2' in getenv('CIBW_ARCHS_MACOS')):

--- a/webp_build/builder.py
+++ b/webp_build/builder.py
@@ -66,9 +66,9 @@ def fetch_cffi_settings(conan_info, cffi_settings):
 
 if platform.architecture()[0] == '32bit' and platform.machine().lower() in {'amd64', 'x86_64', 'x64', 'i686'}:
     arch = 'x86'
-elif 'arm64' in getenv('CIBW_ARCHS_MACOS') or 'universal2' in getenv('CIBW_ARCHS_MACOS'):
+elif getenv('CIBW_ARCHS_MACOS') and ('arm64' in getenv('CIBW_ARCHS_MACOS') or 'universal2' in getenv('CIBW_ARCHS_MACOS')):
     arch = 'armv8'
-elif 'ARM64' in getenv('CIBW_ARCHS_WINDOWS'):
+elif getenv('CIBW_ARCHS_WINDOWS') and 'ARM64' in getenv('CIBW_ARCHS_WINDOWS'):
     arch = 'armv8'
 
 cffi_settings = {


### PR DESCRIPTION
This PR would enable building universal2 wheel that can be installed in both x86_64 and arm64 macOS. I have tested the universal2 wheel on my x86_64 and arm64 macOS machines and confirmed to work. By providing universal2 wheel, it would be more convenient to distribute python applications that uses this library (e.g. Those who build applications with pyinstaller).