### PR TITLE
Use conan2

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -98,6 +98,9 @@ jobs:
           - os: macos-11
             cibw_archs_macos: arm64
             cibw_build: "cp3*-macosx_arm64"
+          - os: macos-11
+            cibw_archs_macos: universal2
+            cibw_build: "cp3*-macosx_universal2"
     steps:
       - name: Fetch source distribution
         uses: actions/download-artifact@v3

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -96,13 +96,13 @@ jobs:
 #            cibw_build: "cp3*-musllinux_*"
           - os: windows-2019
             cibw_archs_windows: AMD64
-            cibw_build: "cp3*-win_*"
+            cibw_build: "cp3*-win*"
           - os: windows-2019
             cibw_archs_windows: x86
-            cibw_build: "cp3*-win_*"
+            cibw_build: "cp3*-win*"
           - os: windows-2019
             cibw_archs_windows: ARM64
-            cibw_build: "cp3*-win_*"
+            cibw_build: "cp3*-win*"
           - os: macos-11
             cibw_archs_macos: x86_64
             cibw_build: "cp3*-macosx_*"

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -56,54 +56,70 @@ jobs:
       matrix:
         include:
           - os: ubuntu-20.04
-            cibw_archs_linux: x86_64
+            cibw_archs: x86_64
             cibw_build: "cp3*-manylinux_*"
+            cibw_environment: PYWEBP_COMPILE_TARGET=x86_64
           - os: ubuntu-20.04
-            cibw_archs_linux: x86_64
+            cibw_archs: x86_64
             cibw_build: "cp3*-musllinux_*"
             cibw_skip: "cp38-musllinux_*"
+            cibw_environment: PYWEBP_COMPILE_TARGET=x86_64
           - os: ubuntu-20.04
-            cibw_archs_linux: aarch64
+            cibw_archs: aarch64
             cibw_build: "cp3*-manylinux_*"
+            cibw_environment: PYWEBP_COMPILE_TARGET=armv8
           # - os: ubuntu-20.04
-          #   cibw_archs_linux: aarch64
+          #   cibw_archs: aarch64
           #   cibw_build: "cp3*-musllinux_*"
+          #   cibw_environment: PYWEBP_COMPILE_TARGET=armv8
           # - os: ubuntu-20.04
-          #   cibw_archs_linux: i686
+          #   cibw_archs: i686
           #   cibw_build: "cp3*-manylinux_*"
+          #   cibw_environment: PYWEBP_COMPILE_TARGET=x86
           # - os: ubuntu-20.04
-          #   cibw_archs_linux: i686
+          #   cibw_archs: i686
           #   cibw_build: "cp3*-musllinux_*"
+          #   cibw_environment: PYWEBP_COMPILE_TARGET=x86
           # - os: ubuntu-20.04
-          #   cibw_archs_linux: ppc64le
+          #   cibw_archs: ppc64le
           #   cibw_build: "cp3*-manylinux_*"
+          #   cibw_environment: PYWEBP_COMPILE_TARGET=ppc64le
           # - os: ubuntu-20.04
-          #   cibw_archs_linux: ppc64le
+          #   cibw_archs: ppc64le
           #   cibw_build: "cp3*-musllinux_*"
+          #   cibw_environment: PYWEBP_COMPILE_TARGET=ppc64le
           # - os: ubuntu-20.04
-          #   cibw_archs_linux: s390x
+          #   cibw_archs: s390x
           #   cibw_build: "cp3*-manylinux_*"
+          #   cibw_environment: PYWEBP_COMPILE_TARGET=s390x
           # - os: ubuntu-20.04
-          #   cibw_archs_linux: s390x
+          #   cibw_archs: s390x
           #   cibw_build: "cp3*-musllinux_*"
+          #   cibw_environment: PYWEBP_COMPILE_TARGET=s390x
           - os: windows-2019
-            cibw_archs_windows: AMD64
+            cibw_archs: AMD64
             cibw_build: "cp3*-win*"
+            cibw_environment: PYWEBP_COMPILE_TARGET=x86_64
           # - os: windows-2019
-          #   cibw_archs_windows: x86
+          #   cibw_archs: x86
           #   cibw_build: "cp3*-win*"
+          #     cibw_environment: PYWEBP_COMPILE_TARGET=x86_64
           - os: windows-2019
-            cibw_archs_windows: ARM64
+            cibw_archs: ARM64
             cibw_build: "cp3*-win*"
+            cibw_environment: PYWEBP_COMPILE_TARGET=armv8
           - os: macos-11
-            cibw_archs_macos: x86_64
+            cibw_archs: x86_64
             cibw_build: "cp3*-macosx_*"
+            cibw_environment: PYWEBP_COMPILE_TARGET=x86_64
           - os: macos-11
-            cibw_archs_macos: arm64
+            cibw_archs: arm64
             cibw_build: "cp3*-macosx_*"
+            cibw_environment: PYWEBP_COMPILE_TARGET=armv8
           - os: macos-11
-            cibw_archs_macos: universal2
+            cibw_archs: universal2
             cibw_build: "cp3*-macosx_*"
+            cibw_environment: PYWEBP_COMPILE_TARGET=universal2
     steps:
       - name: Fetch source distribution
         uses: actions/download-artifact@v3
@@ -112,11 +128,11 @@ jobs:
           path: dist/
       - run: mv dist/webp-*.tar.gz webp.tar.gz
       - name: Set up QEMU
-        if: runner.os == 'Linux' && runner.cibw_archs_linux != 'x86_64'
+        if: runner.os == 'Linux' && runner.cibw_archs != 'x86_64'
         uses: docker/setup-qemu-action@v2
         with:
           platforms: all
-      - name: Build wheels
+      - name: Build wheels for ${{ matrix.os }} ${{ matrix.cibw_archs }} ${{ matrix.cibw_build }}
         uses: pypa/cibuildwheel@v2.15.0
         with:
           package-dir: webp.tar.gz
@@ -125,9 +141,8 @@ jobs:
           CIBW_BUILD_FRONTEND: build
           CIBW_BUILD: ${{ matrix.cibw_build }}
           CIBW_SKIP: ${{ matrix.cibw_skip }}
-          CIBW_ARCHS_LINUX: ${{ matrix.cibw_archs_linux }}
-          CIBW_ARCHS_WINDOWS: ${{ matrix.cibw_archs_windows }}
-          CIBW_ARCHS_MACOS: ${{ matrix.cibw_archs_macos }}
+          CIBW_ARCHS: ${{ matrix.cibw_archs }}
+          CIBW_ENVIRONMENT: ${{ matrix.cibw_environment }}
           # TODO: Use arm64 CI runner when available
           CIBW_TEST_SKIP: "*_arm64"
           # 3.12 ready when:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -111,7 +111,7 @@ jobs:
           path: dist/
       - run: mv dist/webp-*.tar.gz webp.tar.gz
       - name: Set up QEMU
-        if: runner.os == 'Linux' and runner.cibw_archs_linux != 'x86_64'
+        if: runner.os == 'Linux' && runner.cibw_archs_linux != 'x86_64'
         uses: docker/setup-qemu-action@v2
         with:
           platforms: all

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -126,7 +126,7 @@ jobs:
           CIBW_ARCHS_MACOS: ${{ matrix.cibw_archs_macos }}
           # TODO: Use arm64 CI runner when available
           CIBW_TEST_SKIP: "*_arm64"
-          CIBW_PROJECT_REQUIRES_PYTHON: '>=3.8,<3.12'
+          CIBW_PROJECT_REQUIRES_PYTHON: '>=3.8'
           CIBW_TEST_REQUIRES: pytest
           CIBW_TEST_COMMAND: pytest {package}/tests
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -65,10 +65,9 @@ jobs:
           - os: ubuntu-20.04
             cibw_archs_linux: aarch64
             cibw_build: "cp3*-manylinux_*"
-          - os: ubuntu-20.04
-            cibw_archs_linux: aarch64
-            cibw_build: "cp3*-musllinux_*"
-            cibw_skip: "cp38-musllinux_*"
+          # - os: ubuntu-20.04
+          #   cibw_archs_linux: aarch64
+          #   cibw_build: "cp3*-musllinux_*"
           # - os: ubuntu-20.04
           #   cibw_archs_linux: i686
           #   cibw_build: "cp3*-manylinux_*"

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -57,7 +57,16 @@ jobs:
         include:
           - os: ubuntu-20.04
             cibw_archs_linux: x86_64
-            cibw_build: "cp3*-manylinux_x86_64"
+            cibw_build: "cp3*-manylinux_*"
+          - os: ubuntu-20.04
+            cibw_archs_linux: x86_64
+            cibw_build: "cp3*-muslinux_*"
+          - os: ubuntu-20.04
+            cibw_archs_linux: x86_64
+            cibw_build: "cp3*-manylinux_*"
+          - os: ubuntu-20.04
+            cibw_archs_linux: x86_64
+            cibw_build: "cp3*-muslinux_*"
 #          - os: ubuntu-20.04
 #            cibw_archs_linux: x86_64
 #            cibw_build: "*-musllinux_*"

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -62,7 +62,7 @@ jobs:
           - os: ubuntu-20.04
             cibw_archs_linux: x86_64
             cibw_build: "cp3*-musllinux_*"
-            cibw_before_all: yum install -y libffi-devel # May remove when cffi release py3.12 wheel
+            cibw_before_all: apk add libffi-devel # May remove when cffi release py3.12 wheel
           - os: ubuntu-20.04
             cibw_archs_linux: x86_64
             cibw_build: "cp3*-manylinux_*"
@@ -70,7 +70,7 @@ jobs:
           - os: ubuntu-20.04
             cibw_archs_linux: x86_64
             cibw_build: "cp3*-musllinux_*"
-            cibw_before_all: yum install -y libffi-devel # May remove when cffi release py3.12 wheel
+            cibw_before_all: apk add libffi-devel # May remove when cffi release py3.12 wheel
 #          - os: ubuntu-20.04
 #            cibw_archs_linux: x86_64
 #            cibw_build: "cp3*-musllinux_*"

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -62,25 +62,16 @@ jobs:
             cibw_archs_linux: x86_64
             cibw_build: "cp3*-musllinux_*"
           - os: ubuntu-20.04
-            cibw_archs_linux: x86_64
+            cibw_archs_linux: aarch64
             cibw_build: "cp3*-manylinux_*"
           - os: ubuntu-20.04
-            cibw_archs_linux: x86_64
+            cibw_archs_linux: aarch64
             cibw_build: "cp3*-musllinux_*"
 #          - os: ubuntu-20.04
-#            cibw_archs_linux: x86_64
-#            cibw_build: "cp3*-musllinux_*"
-#          - os: ubuntu-20.04
 #            cibw_archs_linux: i686
 #            cibw_build: "cp3*-manylinux_*"
 #          - os: ubuntu-20.04
 #            cibw_archs_linux: i686
-#            cibw_build: "cp3*-musllinux_*"
-#          - os: ubuntu-20.04
-#            cibw_archs_linux: aarch64
-#            cibw_build: "cp3*-manylinux_*"
-#          - os: ubuntu-20.04
-#            cibw_archs_linux: aarch64
 #            cibw_build: "cp3*-musllinux_*"
 #          - os: ubuntu-20.04
 #            cibw_archs_linux: ppc64le

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -62,7 +62,7 @@ jobs:
           - os: ubuntu-20.04
             cibw_archs_linux: x86_64
             cibw_build: "cp3*-musllinux_*"
-            cibw_before_all: apk add libffi-devel # May remove when cffi release py3.12 wheel
+            cibw_before_all: apk add libffi-dev # May remove when cffi release py3.12 wheel
           - os: ubuntu-20.04
             cibw_archs_linux: x86_64
             cibw_build: "cp3*-manylinux_*"
@@ -70,7 +70,7 @@ jobs:
           - os: ubuntu-20.04
             cibw_archs_linux: x86_64
             cibw_build: "cp3*-musllinux_*"
-            cibw_before_all: apk add libffi-devel # May remove when cffi release py3.12 wheel
+            cibw_before_all: apk add libffi-dev # May remove when cffi release py3.12 wheel
 #          - os: ubuntu-20.04
 #            cibw_archs_linux: x86_64
 #            cibw_build: "cp3*-musllinux_*"

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -42,7 +42,7 @@ jobs:
           python-version: 3.8
       - name: Install the package
         run: |
-          python -m pip install -v dist/webp-*.tar.gz
+          python -m pip install dist/webp-*.tar.gz
       - name: Test with pytest
         run: |
           python -m pip install pytest==7.2.1
@@ -69,47 +69,49 @@ jobs:
             cibw_build: "cp3*-musllinux_*"
 #          - os: ubuntu-20.04
 #            cibw_archs_linux: x86_64
-#            cibw_build: "*-musllinux_*"
+#            cibw_build: "cp3*-musllinux_*"
 #          - os: ubuntu-20.04
 #            cibw_archs_linux: i686
-#            cibw_build: "*-manylinux_*"
+#            cibw_build: "cp3*-manylinux_*"
 #          - os: ubuntu-20.04
 #            cibw_archs_linux: i686
-#            cibw_build: "*-musllinux_*"
+#            cibw_build: "cp3*-musllinux_*"
 #          - os: ubuntu-20.04
 #            cibw_archs_linux: aarch64
-#            cibw_build: "*-manylinux_*"
+#            cibw_build: "cp3*-manylinux_*"
 #          - os: ubuntu-20.04
 #            cibw_archs_linux: aarch64
-#            cibw_build: "*-musllinux_*"
+#            cibw_build: "cp3*-musllinux_*"
 #          - os: ubuntu-20.04
 #            cibw_archs_linux: ppc64le
-#            cibw_build: "*-manylinux_*"
+#            cibw_build: "cp3*-manylinux_*"
 #          - os: ubuntu-20.04
 #            cibw_archs_linux: ppc64le
-#            cibw_build: "*-musllinux_*"
+#            cibw_build: "cp3*-musllinux_*"
 #          - os: ubuntu-20.04
 #            cibw_archs_linux: s390x
-#            cibw_build: "*-manylinux_*"
+#            cibw_build: "cp3*-manylinux_*"
 #          - os: ubuntu-20.04
 #            cibw_archs_linux: s390x
-#            cibw_build: "*-musllinux_*"
+#            cibw_build: "cp3*-musllinux_*"
           - os: windows-2019
             cibw_archs_windows: AMD64
-            cibw_build: "cp3*-win_amd64"
-#          - os: windows-2019
-#            cibw_archs_windows: x86
-#          - os: windows-2019
-#            cibw_archs_windows: ARM64
+            cibw_build: "cp3*-win_*"
+          - os: windows-2019
+            cibw_archs_windows: x86
+            cibw_build: "cp3*-win_*"
+          - os: windows-2019
+            cibw_archs_windows: ARM64
+            cibw_build: "cp3*-win_*"
           - os: macos-11
             cibw_archs_macos: x86_64
-            cibw_build: "cp3*-macosx_x86_64"
+            cibw_build: "cp3*-macosx_*"
           - os: macos-11
             cibw_archs_macos: arm64
-            cibw_build: "cp3*-macosx_arm64"
+            cibw_build: "cp3*-macosx_*"
           - os: macos-11
             cibw_archs_macos: universal2
-            cibw_build: "cp3*-macosx_universal2"
+            cibw_build: "cp3*-macosx_*"
     steps:
       - name: Fetch source distribution
         uses: actions/download-artifact@v3

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -42,7 +42,7 @@ jobs:
           python-version: 3.8
       - name: Install the package
         run: |
-          python -m pip install -vvv dist/webp-*.tar.gz
+          python -m pip install -v dist/webp-*.tar.gz
       - name: Test with pytest
         run: |
           python -m pip install pytest==7.2.1

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -42,7 +42,7 @@ jobs:
           python-version: 3.8
       - name: Install the package
         run: |
-          python -m pip install dist/webp-*.tar.gz
+          python -m pip install -vvv dist/webp-*.tar.gz
       - name: Test with pytest
         run: |
           python -m pip install pytest==7.2.1

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -143,9 +143,8 @@ jobs:
           # TODO: Use arm64 CI runner when available
           CIBW_TEST_SKIP: "*_arm64"
           CIBW_PROJECT_REQUIRES_PYTHON: '>=3.8'
-          CIBW_TEST_REQUIRES: pytest
+          CIBW_TEST_REQUIRES: pytest setuptools>=45
           CIBW_TEST_COMMAND: pytest {package}/tests
-          CIBW_TEST_REQUIRES: setuptools>=45
       - uses: actions/upload-artifact@v3
         with:
           name: wheels-${{ github.sha }}

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -61,12 +61,14 @@ jobs:
           - os: ubuntu-20.04
             cibw_archs_linux: x86_64
             cibw_build: "cp3*-musllinux_*"
+            cibw_skip: "cp38-musllinux_*"
           - os: ubuntu-20.04
             cibw_archs_linux: aarch64
             cibw_build: "cp3*-manylinux_*"
           - os: ubuntu-20.04
             cibw_archs_linux: aarch64
             cibw_build: "cp3*-musllinux_*"
+            cibw_skip: "cp38-musllinux_*"
           # - os: ubuntu-20.04
           #   cibw_archs_linux: i686
           #   cibw_build: "cp3*-manylinux_*"
@@ -123,6 +125,7 @@ jobs:
         env:
           CIBW_BUILD_FRONTEND: build
           CIBW_BUILD: ${{ matrix.cibw_build }}
+          CIBW_SKIP: ${{ matrix.cibw_skip }}
           CIBW_ARCHS_LINUX: ${{ matrix.cibw_archs_linux }}
           CIBW_ARCHS_WINDOWS: ${{ matrix.cibw_archs_windows }}
           CIBW_ARCHS_MACOS: ${{ matrix.cibw_archs_macos }}

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -97,9 +97,9 @@ jobs:
           - os: windows-2019
             cibw_archs_windows: AMD64
             cibw_build: "cp3*-win*"
-          - os: windows-2019
-            cibw_archs_windows: x86
-            cibw_build: "cp3*-win*"
+          # - os: windows-2019
+          #   cibw_archs_windows: x86
+          #   cibw_build: "cp3*-win*"
           - os: windows-2019
             cibw_archs_windows: ARM64
             cibw_build: "cp3*-win*"

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -60,13 +60,13 @@ jobs:
             cibw_build: "cp3*-manylinux_*"
           - os: ubuntu-20.04
             cibw_archs_linux: x86_64
-            cibw_build: "cp3*-muslinux_*"
+            cibw_build: "cp3*-musllinux_*"
           - os: ubuntu-20.04
             cibw_archs_linux: x86_64
             cibw_build: "cp3*-manylinux_*"
           - os: ubuntu-20.04
             cibw_archs_linux: x86_64
-            cibw_build: "cp3*-muslinux_*"
+            cibw_build: "cp3*-musllinux_*"
 #          - os: ubuntu-20.04
 #            cibw_archs_linux: x86_64
 #            cibw_build: "*-musllinux_*"

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -58,15 +58,19 @@ jobs:
           - os: ubuntu-20.04
             cibw_archs_linux: x86_64
             cibw_build: "cp3*-manylinux_*"
+            cibw_before_all: yum install -y libffi-devel # May remove when cffi release py3.12 wheel
           - os: ubuntu-20.04
             cibw_archs_linux: x86_64
             cibw_build: "cp3*-musllinux_*"
+            cibw_before_all: yum install -y libffi-devel # May remove when cffi release py3.12 wheel
           - os: ubuntu-20.04
             cibw_archs_linux: x86_64
             cibw_build: "cp3*-manylinux_*"
+            cibw_before_all: yum install -y libffi-devel # May remove when cffi release py3.12 wheel
           - os: ubuntu-20.04
             cibw_archs_linux: x86_64
             cibw_build: "cp3*-musllinux_*"
+            cibw_before_all: yum install -y libffi-devel # May remove when cffi release py3.12 wheel
 #          - os: ubuntu-20.04
 #            cibw_archs_linux: x86_64
 #            cibw_build: "cp3*-musllinux_*"
@@ -135,6 +139,7 @@ jobs:
           CIBW_ARCHS_LINUX: ${{ matrix.cibw_archs_linux }}
           CIBW_ARCHS_WINDOWS: ${{ matrix.cibw_archs_windows }}
           CIBW_ARCHS_MACOS: ${{ matrix.cibw_archs_macos }}
+          CIBW_BEFORE_ALL: ${{ matrix.cibw_before_all }} # May remove when cffi release py3.12 wheel
           # TODO: Use arm64 CI runner when available
           CIBW_TEST_SKIP: "*_arm64"
           CIBW_PROJECT_REQUIRES_PYTHON: '>=3.8'

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -58,19 +58,15 @@ jobs:
           - os: ubuntu-20.04
             cibw_archs_linux: x86_64
             cibw_build: "cp3*-manylinux_*"
-            cibw_before_all: yum install -y libffi-devel # May remove when cffi release py3.12 wheel
           - os: ubuntu-20.04
             cibw_archs_linux: x86_64
             cibw_build: "cp3*-musllinux_*"
-            cibw_before_all: apk add libffi-dev # May remove when cffi release py3.12 wheel
           - os: ubuntu-20.04
             cibw_archs_linux: x86_64
             cibw_build: "cp3*-manylinux_*"
-            cibw_before_all: yum install -y libffi-devel # May remove when cffi release py3.12 wheel
           - os: ubuntu-20.04
             cibw_archs_linux: x86_64
             cibw_build: "cp3*-musllinux_*"
-            cibw_before_all: apk add libffi-dev # May remove when cffi release py3.12 wheel
 #          - os: ubuntu-20.04
 #            cibw_archs_linux: x86_64
 #            cibw_build: "cp3*-musllinux_*"
@@ -139,11 +135,13 @@ jobs:
           CIBW_ARCHS_LINUX: ${{ matrix.cibw_archs_linux }}
           CIBW_ARCHS_WINDOWS: ${{ matrix.cibw_archs_windows }}
           CIBW_ARCHS_MACOS: ${{ matrix.cibw_archs_macos }}
-          CIBW_BEFORE_ALL: ${{ matrix.cibw_before_all }} # May remove when cffi release py3.12 wheel
           # TODO: Use arm64 CI runner when available
           CIBW_TEST_SKIP: "*_arm64"
-          CIBW_PROJECT_REQUIRES_PYTHON: '>=3.8'
-          CIBW_TEST_REQUIRES: pytest setuptools>=45
+          # 3.12 ready when:
+          # cffi releases 3.12 wheel
+          # numpy release 3.12 wheel
+          CIBW_PROJECT_REQUIRES_PYTHON: '>=3.8,<3.12'
+          CIBW_TEST_REQUIRES: pytest
           CIBW_TEST_COMMAND: pytest {package}/tests
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -67,24 +67,24 @@ jobs:
           - os: ubuntu-20.04
             cibw_archs_linux: aarch64
             cibw_build: "cp3*-musllinux_*"
-#          - os: ubuntu-20.04
-#            cibw_archs_linux: i686
-#            cibw_build: "cp3*-manylinux_*"
-#          - os: ubuntu-20.04
-#            cibw_archs_linux: i686
-#            cibw_build: "cp3*-musllinux_*"
-#          - os: ubuntu-20.04
-#            cibw_archs_linux: ppc64le
-#            cibw_build: "cp3*-manylinux_*"
-#          - os: ubuntu-20.04
-#            cibw_archs_linux: ppc64le
-#            cibw_build: "cp3*-musllinux_*"
-#          - os: ubuntu-20.04
-#            cibw_archs_linux: s390x
-#            cibw_build: "cp3*-manylinux_*"
-#          - os: ubuntu-20.04
-#            cibw_archs_linux: s390x
-#            cibw_build: "cp3*-musllinux_*"
+          # - os: ubuntu-20.04
+          #   cibw_archs_linux: i686
+          #   cibw_build: "cp3*-manylinux_*"
+          # - os: ubuntu-20.04
+          #   cibw_archs_linux: i686
+          #   cibw_build: "cp3*-musllinux_*"
+          # - os: ubuntu-20.04
+          #   cibw_archs_linux: ppc64le
+          #   cibw_build: "cp3*-manylinux_*"
+          # - os: ubuntu-20.04
+          #   cibw_archs_linux: ppc64le
+          #   cibw_build: "cp3*-musllinux_*"
+          # - os: ubuntu-20.04
+          #   cibw_archs_linux: s390x
+          #   cibw_build: "cp3*-manylinux_*"
+          # - os: ubuntu-20.04
+          #   cibw_archs_linux: s390x
+          #   cibw_build: "cp3*-musllinux_*"
           - os: windows-2019
             cibw_archs_windows: AMD64
             cibw_build: "cp3*-win*"
@@ -110,11 +110,11 @@ jobs:
           name: sdist-${{ github.sha }}
           path: dist/
       - run: mv dist/webp-*.tar.gz webp.tar.gz
-#      - name: Set up QEMU
-#        if: runner.os == 'Linux'
-#        uses: docker/setup-qemu-action@v2
-#        with:
-#          platforms: all
+      - name: Set up QEMU
+        if: runner.os == 'Linux' and runner.cibw_archs_linux != 'x86_64'
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: all
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.15.0
         with:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -145,6 +145,7 @@ jobs:
           CIBW_PROJECT_REQUIRES_PYTHON: '>=3.8'
           CIBW_TEST_REQUIRES: pytest
           CIBW_TEST_COMMAND: pytest {package}/tests
+          CIBW_TEST_REQUIRES: setuptools>=45
       - uses: actions/upload-artifact@v3
         with:
           name: wheels-${{ github.sha }}

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ __pycache__/
 # Temporary files
 *.swp
 *~
+conan_output
 
 # IDE configuration
 .idea/

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,6 @@
 include README.md
 include LICENSE
-include conanfile.txt
+include conanfile.py
 include pyproject.toml
 
 graft webp_build

--- a/conanfile.py
+++ b/conanfile.py
@@ -6,6 +6,5 @@ class LibwebpRecipe(ConanFile):
         self.requires("libwebp/1.0.3")
 
     def build_requirements(self):
-        # if self.settings.arch in ("x86_64", "armv8"):
         if not shutil.which('cmake'):
             self.tool_requires("cmake/[>=3.5]")

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,0 +1,13 @@
+from conan import ConanFile
+
+class CompressorRecipe(ConanFile):
+    # Binary configuration
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "CMakeToolchain", "CMakeDeps"
+
+    def requirements(self):
+        self.requires("libwebp/1.0.3")
+
+    def build_requirements(self):
+        # if self.settings.arch in ("x86_64", "armv8"):
+        self.tool_requires("cmake/3.22.6")

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,4 +1,5 @@
 from conan import ConanFile
+import shutil
 
 class LibwebpRecipe(ConanFile):
     def requirements(self):
@@ -6,4 +7,5 @@ class LibwebpRecipe(ConanFile):
 
     def build_requirements(self):
         # if self.settings.arch in ("x86_64", "armv8"):
-        self.tool_requires("cmake/[>=3.5]")
+        if not shutil.which('cmake'):
+            self.tool_requires("cmake/[>=3.5]")

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,10 +1,6 @@
 from conan import ConanFile
 
-class CompressorRecipe(ConanFile):
-    # Binary configuration
-    settings = "os", "compiler", "build_type", "arch"
-    generators = "CMakeToolchain", "CMakeDeps"
-
+class LibwebpRecipe(ConanFile):
     def requirements(self):
         self.requires("libwebp/1.0.3")
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -6,4 +6,4 @@ class LibwebpRecipe(ConanFile):
 
     def build_requirements(self):
         # if self.settings.arch in ("x86_64", "armv8"):
-        self.tool_requires("cmake/3.22.6")
+        self.tool_requires("cmake/[>=3.5]")

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,5 +1,0 @@
-[requires]
-libwebp/1.0.3
-
-[generators]
-json

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ test = [
 ]
 dev = [
     "build>=1.0.0",
-    "conan>=1.8.0,<2.0",
+    "conan>=2.0",
     "conda-lock>=2.0.0",
     "twine",
 ]
@@ -34,7 +34,7 @@ homepage = "https://github.com/anibali/pywebp"
 [build-system]
 requires = [
     "cffi>=1.0.0",
-    "conan>=1.8.0,<2.0",
+    "conan>=2.0",
     "setuptools>=45",
     "wheel",
 ]

--- a/webp_build/builder.py
+++ b/webp_build/builder.py
@@ -3,73 +3,102 @@ import platform
 import tempfile
 from importlib.resources import read_text
 from os import path, getcwd, getenv
+import platform
 
 from cffi import FFI
 from conans.client import conan_api
 
 import webp_build
 
-conan, _, _ = conan_api.ConanAPIV1.factory()
+def install_libwebp(arch=None):
+    # Use Conan to install libwebp
 
-# Use Conan to install libwebp
-settings = []
-if platform.architecture()[0] == '32bit' and platform.machine().lower() in {'amd64', 'x86_64', 'x64', 'i686'}:
-    settings.append('arch=x86')
-if getenv('CIBW_ARCHS_MACOS') == 'arm64':
-    # https://blog.conan.io/2021/09/21/m1.html
-    settings.append('os=Macos')
-    settings.append('arch=armv8')
-    settings.append('compiler=apple-clang')
-    settings.append('compiler.version=11.0')
-    settings.append('compiler.libcxx=libc++')
-elif getenv('CIBW_ARCHS_WINDOWS') == 'ARM64':
-    settings.append('os=Windows')
-    settings.append('arch=armv8')
-if getenv('CIBW_BUILD') and 'musllinux' in getenv('CIBW_BUILD'):
-    build_policy = ['always']
-else:
-    build_policy = ['missing']
+    conan, _, _ = conan_api.ConanAPIV1.factory()
 
-with tempfile.TemporaryDirectory() as tmp_dir:
-    conan.install(path=getcwd(), cwd=tmp_dir, settings=settings, build=build_policy)
-    with open(path.join(tmp_dir, 'conanbuildinfo.json'), 'r') as f:
-        conan_info = json.load(f)
+    settings = []
+    if platform.system() == 'Windows':
+        settings.append('os=Windows')
+    elif platform.system() == 'Darwin':
+        settings.append('os=Macos')
+        settings.append('compiler=apple-clang')
+        settings.append('compiler.version=11.0')
+        settings.append('compiler.libcxx=libc++')
+    elif platform.system() == 'Linux':
+        settings.append('os=Linux')
 
-# Find header files and libraries in libwebp
-extra_objects = []
-extra_compile_args = []
-include_dirs = []
-libraries = []
-for dep in conan_info['dependencies']:
-    for lib_name in dep['libs']:
-        if platform.system() == 'Windows':
-            lib_filename = '{}.lib'.format(lib_name)
-        else:
-            lib_filename = 'lib{}.a'.format(lib_name)
-        for lib_path in dep['lib_paths']:
-            candidate = path.join(lib_path, lib_filename)
-            if path.isfile(candidate):
-                extra_objects.append(candidate)
+    if arch:
+        settings.append(f'arch={arch}')
+
+    if getenv('CIBW_BUILD') and 'musllinux' in getenv('CIBW_BUILD'):
+        build_policy = ['always']
+    else:
+        build_policy = ['missing']
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        conan.install(path=getcwd(), cwd=tmp_dir, settings=settings, build=build_policy)
+        with open(path.join(tmp_dir, 'conanbuildinfo.json'), 'r') as f:
+            conan_info = json.load(f)
+    
+    return conan_info
+
+def fetch_cffi_settings(conan_info, cffi_settings):
+    # Find header files and libraries in libwebp
+
+    for dep in conan_info['dependencies']:
+        for lib_name in dep['libs']:
+            if platform.system() == 'Windows':
+                lib_filename = '{}.lib'.format(lib_name)
             else:
-                libraries.append(lib_name)
-    for include_path in dep['include_paths']:
-        include_dirs.append(include_path)
+                lib_filename = 'lib{}.a'.format(lib_name)
+            for lib_path in dep['lib_paths']:
+                candidate = path.join(lib_path, lib_filename)
+                if path.isfile(candidate):
+                    cffi_settings['extra_objects'].append(candidate)
+                else:
+                    cffi_settings['libraries'].append(lib_name)
+        for include_path in dep['include_paths']:
+            cffi_settings['include_dirs'].append(include_path)
+    
+    if  platform.system() == 'Darwin':
+        cffi_settings['extra_compile_args'].append('-mmacosx-version-min=11.0')
+    
+    return cffi_settings
 
-if getenv('CIBW_ARCHS_MACOS') == 'arm64':
-    extra_compile_args.append('--target=arm64-apple-macos11')
+def main():
+    if platform.architecture()[0] == '32bit' and platform.machine().lower() in {'amd64', 'x86_64', 'x64', 'i686'}:
+        arch = 'x86'
+    elif 'arm64' in getenv('CIBW_ARCHS_MACOS') or 'universal2' in getenv('CIBW_ARCHS_MACOS'):
+        arch = 'armv8'
+    elif 'ARM64' in getenv('CIBW_ARCHS_WINDOWS'):
+        arch = 'armv8'
 
-# Specify C sources to be built by CFFI
-ffibuilder = FFI()
-ffibuilder.set_source(
-    '_webp',
-    read_text(webp_build, 'source.c'),
-    extra_objects=extra_objects,
-    extra_compile_args=extra_compile_args,
-    include_dirs=include_dirs,
-    libraries=libraries,
-)
-ffibuilder.cdef(read_text(webp_build, 'cdef.h'))
+    cffi_settings = {
+        'extra_objects': [],
+        'extra_compile_args': [],
+        'include_dirs': [],
+        'libraries': []
+    }
 
+    conan_info = install_libwebp(arch)
+    cffi_settings = fetch_cffi_settings(conan_info, cffi_settings)
+    if 'universal2' in getenv('CIBW_ARCHS_MACOS'):
+        # Repeat to install the other architecture version of libwebp
+        conan_info = install_libwebp('x86_64')
+        cffi_settings = fetch_cffi_settings(conan_info, cffi_settings)
+
+    # Specify C sources to be built by CFFI
+    ffibuilder = FFI()
+    ffibuilder.set_source(
+        '_webp',
+        read_text(webp_build, 'source.c'),
+        extra_objects=cffi_settings['extra_objects'],
+        extra_compile_args=cffi_settings['extra_compile_args'],
+        include_dirs=cffi_settings['include_dirs'],
+        libraries=cffi_settings['libraries'],
+    )
+    ffibuilder.cdef(read_text(webp_build, 'cdef.h'))
+
+    ffibuilder.compile(verbose=True)
 
 if __name__ == '__main__':
-    ffibuilder.compile(verbose=True)
+    main()

--- a/webp_build/builder.py
+++ b/webp_build/builder.py
@@ -51,17 +51,23 @@ def fetch_cffi_settings(conan_info, cffi_settings):
         if dep.get('package_folder') == None:
             continue
         
-        for lib_name, i in reversed(dep['cpp_info'].items()):
-            for include_dir in dep['cpp_info'][lib_name].get('includedirs', []):
+        for lib, i in reversed(dep['cpp_info'].items()):
+            for include_dir in dep['cpp_info'][lib].get('includedirs', []):
                 cffi_settings['include_dirs'].append(include_dir) if include_dir not in cffi_settings['include_dirs'] else None
 
-            for lib_name in i.get('libs', []):
+            if not i.get('libs'):
+                continue
+
+            for lib_name in i.get('libs'):
                 if platform.system() == 'Windows':
                     lib_filename = '{}.lib'.format(lib_name)
                 else:
                     lib_filename = 'lib{}.a'.format(lib_name)
                 
-                for lib_dir in i.get('libdirs', []):
+                if not i.get('libdirs'):
+                    continue
+
+                for lib_dir in i.get('libdirs'):
                     lib_path = os.path.join(lib_dir, lib_filename)
                     if os.path.isfile(lib_path):
                         cffi_settings['extra_objects'].append(lib_path)

--- a/webp_build/builder.py
+++ b/webp_build/builder.py
@@ -36,6 +36,7 @@ def install_libwebp(arch=None):
     result = subprocess.run(['conan', 'install', *settings, 
                              '-of', 'conan_output', '--deployer=full_deploy',
                              '--format=json', '.'], stdout=subprocess.PIPE).stdout.decode()
+    print(result)
     conan_info = json.loads(result)
     # print(conan_info)
     

--- a/webp_build/builder.py
+++ b/webp_build/builder.py
@@ -23,6 +23,9 @@ def install_libwebp(arch=None):
         settings.append('-s:h compiler.libcxx=libc++')
     elif platform.system() == 'Linux':
         settings.append('-s:h os=Linux')
+        settings.append('-s:h compiler=gcc')
+        settings.append('-s:h compiler.version=10')
+        settings.append('-s:h compiler.libcxx=libstdc++')
 
     if arch:
         settings.append(f'-s:h arch={arch}')

--- a/webp_build/builder.py
+++ b/webp_build/builder.py
@@ -41,7 +41,7 @@ def install_libwebp(arch=None):
         'conan', 'install', 
         *[x for s in settings for x in ('-s', s)],
         *[x for b in build for x in ('-b', b)],
-        '-of', 'conan_output', '--deployer=full_deploy', '--format=json', '.'
+        '-of', 'conan_output', '--deployer=direct_deploy', '--format=json', '.'
         ], stdout=subprocess.PIPE).stdout.decode()
     # print(result)
     conan_info = json.loads(result)

--- a/webp_build/builder.py
+++ b/webp_build/builder.py
@@ -15,20 +15,20 @@ def install_libwebp(arch=None):
     settings = []
 
     if platform.system() == 'Windows':
-        settings.append('-s os=Windows')
+        settings.append('os=Windows')
     elif platform.system() == 'Darwin':
-        settings.append('-s os=Macos')
-        settings.append('-s compiler=apple-clang')
-        settings.append('-s compiler.version=11.0')
-        settings.append('-s compiler.libcxx=libc++')
+        settings.append('os=Macos')
+        settings.append('compiler=apple-clang')
+        settings.append('compiler.version=11.0')
+        settings.append('compiler.libcxx=libc++')
     elif platform.system() == 'Linux':
-        settings.append('-s os=Linux')
-        settings.append('-s compiler=gcc')
-        settings.append('-s compiler.version=10')
-        settings.append('-s compiler.libcxx=libstdc++')
+        settings.append('os=Linux')
+        settings.append('compiler=gcc')
+        settings.append('compiler.version=10')
+        settings.append('compiler.libcxx=libstdc++')
 
     if arch:
-        settings.append(f'-s arch={arch}')
+        settings.append(f'arch={arch}')
 
     if os.path.isdir('/lib') and len([i for i in os.listdir('/lib') if i.startswith('libc.musl')]) != 0:
         # Need to compile libwebp if musllinux
@@ -37,7 +37,7 @@ def install_libwebp(arch=None):
         settings.append('--build=missing')
     
     subprocess.run(['conan', 'profile', 'detect'])
-    result = subprocess.run(['conan', 'install', *settings, 
+    result = subprocess.run(['conan', 'install', *[x for s in settings for x in ('-s', s)], 
                             #  '-of', 'conan_output', '--deployer=full_deploy',
                              '--format=json', '.'], stdout=subprocess.PIPE).stdout.decode()
     # print(result)

--- a/webp_build/builder.py
+++ b/webp_build/builder.py
@@ -32,6 +32,7 @@ def install_libwebp(arch=None):
     else:
         settings.append('--build=missing')
     
+    subprocess.run(['conan', 'profile', 'detect'])
     result = subprocess.run(['conan', 'install', *settings, '--format=json', '.'], stdout=subprocess.PIPE).stdout.decode()
     conan_info = json.loads(result)
     

--- a/webp_build/builder.py
+++ b/webp_build/builder.py
@@ -67,11 +67,14 @@ def install_libwebp(arch=None):
         build.append('cmake*')
     
     subprocess.run(['conan', 'profile', 'detect'])
+
+    conan_output = os.path.join('conan_output', arch)
+
     result = subprocess.run([
         'conan', 'install', 
         *[x for s in settings for x in ('-s', s)],
         *[x for b in build for x in ('-b', b)],
-        '-of', 'conan_output', '--deployer=direct_deploy', '--format=json', '.'
+        '-of', conan_output, '--deployer=direct_deploy', '--format=json', '.'
         ], stdout=subprocess.PIPE).stdout.decode()
     # print(result)
     conan_info = json.loads(result)

--- a/webp_build/builder.py
+++ b/webp_build/builder.py
@@ -81,7 +81,7 @@ cffi_settings = {
 
 conan_info = install_libwebp(arch)
 cffi_settings = fetch_cffi_settings(conan_info, cffi_settings)
-if 'universal2' in getenv('CIBW_ARCHS_MACOS'):
+if getenv('CIBW_ARCHS_MACOS') and 'universal2' in getenv('CIBW_ARCHS_MACOS'):
     # Repeat to install the other architecture version of libwebp
     conan_info = install_libwebp('x86_64')
     cffi_settings = fetch_cffi_settings(conan_info, cffi_settings)

--- a/webp_build/builder.py
+++ b/webp_build/builder.py
@@ -64,6 +64,7 @@ def fetch_cffi_settings(conan_info, cffi_settings):
     
     return cffi_settings
 
+arch = None
 if platform.architecture()[0] == '32bit' and platform.machine().lower() in {'amd64', 'x86_64', 'x64', 'i686'}:
     arch = 'x86'
 elif getenv('CIBW_ARCHS_MACOS') and ('arm64' in getenv('CIBW_ARCHS_MACOS') or 'universal2' in getenv('CIBW_ARCHS_MACOS')):

--- a/webp_build/builder.py
+++ b/webp_build/builder.py
@@ -125,11 +125,14 @@ if platform.system() == 'Darwin':
     else:
         cffi_settings['extra_compile_args'].append('-mmacosx-version-min=11.0')
 
-conan_info = install_libwebp(arch)
-cffi_settings = fetch_cffi_settings(conan_info, cffi_settings)
+
 if PYWEBP_COMPILE_TARGET == 'universal2':
-    # Repeat to install the other architecture version of libwebp
     conan_info = install_libwebp('x86_64')
+    cffi_settings = fetch_cffi_settings(conan_info, cffi_settings)
+    conan_info = install_libwebp('armv8')
+    cffi_settings = fetch_cffi_settings(conan_info, cffi_settings)
+else:
+    conan_info = install_libwebp(arch)
     cffi_settings = fetch_cffi_settings(conan_info, cffi_settings)
 
 # Specify C sources to be built by CFFI

--- a/webp_build/builder.py
+++ b/webp_build/builder.py
@@ -57,8 +57,10 @@ def fetch_cffi_settings(conan_info, cffi_settings):
             
             for include_dir in i.get('includedirs', []):
                 cffi_settings['include_dirs'].append(include_dir) if include_dir not in cffi_settings['include_dirs'] else None
-        
-            for lib_name in i.get('libs', []):
+
+            lib_names = ['webpdecoder', 'webpdemux', 'webpmux', 'webp'] # DEBUG
+            # for lib_name in i.get('libs', []):
+            for lib_name in lib_names:
                 if platform.system() == 'Windows':
                     lib_filename = '{}.lib'.format(lib_name)
                 else:
@@ -68,6 +70,8 @@ def fetch_cffi_settings(conan_info, cffi_settings):
                     lib_path = os.path.join(lib_dir, lib_filename)
                     if os.path.isfile(lib_path):
                         cffi_settings['extra_objects'].append(lib_path)
+                    # else:
+                    #     cffi_settings['libraries'].append(lib_name)
     
     if platform.system() == 'Darwin':
         cffi_settings['extra_compile_args'].append('-mmacosx-version-min=11.0')

--- a/webp_build/builder.py
+++ b/webp_build/builder.py
@@ -15,20 +15,20 @@ def install_libwebp(arch=None):
     settings = []
 
     if platform.system() == 'Windows':
-        settings.append('os=Windows')
+        settings.append('os="Windows"')
     elif platform.system() == 'Darwin':
-        settings.append('os=Macos')
-        settings.append('compiler=apple-clang')
-        settings.append('compiler.version=11.0')
-        settings.append('compiler.libcxx=libc++')
+        settings.append('os="Macos"')
+        settings.append('compiler="apple-clang"')
+        settings.append('compiler.version="11.0"')
+        settings.append('compiler.libcxx="libc++"')
     elif platform.system() == 'Linux':
-        settings.append('os=Linux')
-        settings.append('compiler=gcc')
-        settings.append('compiler.version=10')
-        settings.append('compiler.libcxx=libstdc++')
+        settings.append('os="Linux"')
+        settings.append('compiler="gcc"')
+        settings.append('compiler.version="10"')
+        settings.append('compiler.libcxx="libstdc++"')
 
     if arch:
-        settings.append(f'arch={arch}')
+        settings.append(f'arch="{arch}"')
 
     if os.path.isdir('/lib') and len([i for i in os.listdir('/lib') if i.startswith('libc.musl')]) != 0:
         # Need to compile libwebp if musllinux

--- a/webp_build/builder.py
+++ b/webp_build/builder.py
@@ -30,9 +30,9 @@ def install_libwebp(arch=None):
     build = []
     if os.path.isdir('/lib') and len([i for i in os.listdir('/lib') if i.startswith('libc.musl')]) != 0:
         # Need to compile libwebp if musllinux
-        build.append('libwebp')
+        build.append('libwebp*')
     if not platform.machine().lower().startswith(('amd64', 'x86_64', 'x64', 'arm64', 'aarch64', 'armv8')):
-        build.append('cmake')
+        build.append('cmake*')
     if build == []:
         build.append('missing')
     

--- a/webp_build/builder.py
+++ b/webp_build/builder.py
@@ -15,31 +15,39 @@ def install_libwebp(arch=None):
     settings = []
 
     if platform.system() == 'Windows':
-        settings.append('os="Windows"')
+        settings.append('os=Windows')
     elif platform.system() == 'Darwin':
-        settings.append('os="Macos"')
-        settings.append('compiler="apple-clang"')
-        settings.append('compiler.version="11.0"')
-        settings.append('compiler.libcxx="libc++"')
+        settings.append('os=Macos')
+        settings.append('compiler=apple-clang')
+        settings.append('compiler.version=11.0')
+        settings.append('compiler.libcxx=libc++')
     elif platform.system() == 'Linux':
-        settings.append('os="Linux"')
-        settings.append('compiler="gcc"')
-        settings.append('compiler.version="10"')
-        settings.append('compiler.libcxx="libstdc++"')
+        settings.append('os=Linux')
+        settings.append('compiler=gcc')
+        settings.append('compiler.version=10')
+        settings.append('compiler.libcxx=libstdc++')
 
     if arch:
-        settings.append(f'arch="{arch}"')
+        settings.append(f'arch={arch}')
 
     if os.path.isdir('/lib') and len([i for i in os.listdir('/lib') if i.startswith('libc.musl')]) != 0:
         # Need to compile libwebp if musllinux
-        settings.append('--build="*"')
+        build_mode = '*'
     else:
-        settings.append('--build=missing')
+        build_mode = 'missing'
+    
+    print(settings)
+    print([x for s in settings for x in ('-s', s)])
+    print(['conan', 'install', *[x for s in settings for x in ('-s', s)], 
+                             '-of', 'conan_output', '--deployer=full_deploy',
+                             '--format=json', '.'])
     
     subprocess.run(['conan', 'profile', 'detect'])
-    result = subprocess.run(['conan', 'install', *[x for s in settings for x in ('-s', s)], 
-                            #  '-of', 'conan_output', '--deployer=full_deploy',
-                             '--format=json', '.'], stdout=subprocess.PIPE).stdout.decode()
+    result = subprocess.run([
+        'conan', 'install', *[x for s in settings for x in ('-s', s)], 
+        '-of', 'conan_output', '--deployer=full_deploy',
+        '--build', build_mode, '--format=json', '.'
+        ], stdout=subprocess.PIPE).stdout.decode()
     # print(result)
     conan_info = json.loads(result)
     

--- a/webp_build/builder.py
+++ b/webp_build/builder.py
@@ -4,6 +4,7 @@ from importlib.resources import read_text
 import os
 import subprocess
 import platform
+import shutil
 
 from cffi import FFI
 
@@ -53,14 +54,16 @@ def install_libwebp(arch=None):
     if arch:
         settings.append(f'arch={arch}')
 
-    build = []
+    build = ['missing']
     if os.path.isdir('/lib') and len([i for i in os.listdir('/lib') if i.startswith('libc.musl')]) != 0:
         # Need to compile libwebp if musllinux
         build.append('libwebp*')
-    if not platform.machine().lower() in conan_archs['armv8']:
+        
+    if (not shutil.which('cmake') and 
+        (platform.architecture()[0] == '32bit' or 
+        platform.machine().lower() not in (conan_archs['armv8'] + conan_archs['x86']))):
+
         build.append('cmake*')
-    if build == []:
-        build.append('missing')
     
     subprocess.run(['conan', 'profile', 'detect'])
     result = subprocess.run([

--- a/webp_build/builder.py
+++ b/webp_build/builder.py
@@ -18,8 +18,11 @@ def install_libwebp(arch=None):
         settings.append('os=Windows')
     elif platform.system() == 'Darwin':
         settings.append('os=Macos')
+        if arch == 'x86_64':
+            settings.append('os.version=10.9')
+        else:
+            settings.append('os.version=11.0')
         settings.append('compiler=apple-clang')
-        settings.append('compiler.version=11.0')
         settings.append('compiler.libcxx=libc++')
     elif platform.system() == 'Linux':
         settings.append('os=Linux')
@@ -78,9 +81,6 @@ def fetch_cffi_settings(conan_info, cffi_settings):
                     else:
                         cffi_settings['libraries'].append(lib_name)
     
-    if platform.system() == 'Darwin':
-        cffi_settings['extra_compile_args'].append('-mmacosx-version-min=11.0')
-    
     print(f'{cffi_settings = }')
     
     return cffi_settings
@@ -99,6 +99,12 @@ cffi_settings = {
     'include_dirs': [],
     'libraries': []
 }
+
+if platform.system() == 'Darwin':
+    if arch == 'x86_64':
+        cffi_settings['extra_compile_args'].append('-mmacosx-version-min=10.9')
+    else:
+        cffi_settings['extra_compile_args'].append('-mmacosx-version-min=11.0')
 
 conan_info = install_libwebp(arch)
 cffi_settings = fetch_cffi_settings(conan_info, cffi_settings)

--- a/webp_build/builder.py
+++ b/webp_build/builder.py
@@ -66,9 +66,9 @@ def fetch_cffi_settings(conan_info, cffi_settings):
 
 if platform.architecture()[0] == '32bit' and platform.machine().lower() in {'amd64', 'x86_64', 'x64', 'i686'}:
     arch = 'x86'
-elif 'arm64' in getenv('CIBW_ARCHS_MACOS') or 'universal2' in getenv('CIBW_ARCHS_MACOS'):
+elif getenv('CIBW_ARCHS_MACOS') and ('arm64' in getenv('CIBW_ARCHS_MACOS') or 'universal2' in getenv('CIBW_ARCHS_MACOS')):
     arch = 'armv8'
-elif 'ARM64' in getenv('CIBW_ARCHS_WINDOWS'):
+elif getenv('CIBW_ARCHS_WINDOWS') and 'ARM64' in getenv('CIBW_ARCHS_WINDOWS'):
     arch = 'armv8'
 
 cffi_settings = {

--- a/webp_build/builder.py
+++ b/webp_build/builder.py
@@ -23,9 +23,6 @@ def install_libwebp(arch=None):
         settings.append('compiler.libcxx=libc++')
     elif platform.system() == 'Linux':
         settings.append('os=Linux')
-        settings.append('compiler=gcc')
-        settings.append('compiler.version=10')
-        settings.append('compiler.libcxx=libstdc++')
 
     if arch:
         settings.append(f'arch={arch}')
@@ -45,7 +42,7 @@ def install_libwebp(arch=None):
     subprocess.run(['conan', 'profile', 'detect'])
     result = subprocess.run([
         'conan', 'install', *[x for s in settings for x in ('-s', s)], 
-        '-of', 'conan_output', '--deployer=full_deploy',
+        # '-of', 'conan_output', '--deployer=full_deploy',
         '--build', build_mode, '--format=json', '.'
         ], stdout=subprocess.PIPE).stdout.decode()
     # print(result)

--- a/webp_build/builder.py
+++ b/webp_build/builder.py
@@ -15,29 +15,30 @@ def install_libwebp(arch=None):
     settings = []
 
     if platform.system() == 'Windows':
-        settings.append('-s:h os=Windows')
+        settings.append('-s os=Windows')
     elif platform.system() == 'Darwin':
-        settings.append('-s:h os=Macos')
-        settings.append('-s:h compiler=apple-clang')
-        settings.append('-s:h compiler.version=11.0')
-        settings.append('-s:h compiler.libcxx=libc++')
+        settings.append('-s os=Macos')
+        settings.append('-s compiler=apple-clang')
+        settings.append('-s compiler.version=11.0')
+        settings.append('-s compiler.libcxx=libc++')
     elif platform.system() == 'Linux':
-        settings.append('-s:h os=Linux')
-        settings.append('-s:h compiler=gcc')
-        settings.append('-s:h compiler.version=10')
-        settings.append('-s:h compiler.libcxx=libstdc++')
+        settings.append('-s os=Linux')
+        settings.append('-s compiler=gcc')
+        settings.append('-s compiler.version=10')
+        settings.append('-s compiler.libcxx=libstdc++')
 
     if arch:
-        settings.append(f'-s:h arch={arch}')
+        settings.append(f'-s arch={arch}')
 
-    if os.getenv('CIBW_BUILD') and 'musllinux' in os.getenv('CIBW_BUILD'):
+    if os.path.isdir('/lib') and len([i for i in os.listdir('/lib') if i.startswith('libc.musl')]) != 0:
+        # Need to compile libwebp if musllinux
         settings.append('--build="*"')
     else:
         settings.append('--build=missing')
     
     subprocess.run(['conan', 'profile', 'detect'])
     result = subprocess.run(['conan', 'install', *settings, 
-                             '-of', 'conan_output', '--deployer=full_deploy',
+                            #  '-of', 'conan_output', '--deployer=full_deploy',
                              '--format=json', '.'], stdout=subprocess.PIPE).stdout.decode()
     # print(result)
     conan_info = json.loads(result)

--- a/webp_build/builder.py
+++ b/webp_build/builder.py
@@ -27,17 +27,21 @@ def install_libwebp(arch=None):
     if arch:
         settings.append(f'arch={arch}')
 
+    build = []
     if os.path.isdir('/lib') and len([i for i in os.listdir('/lib') if i.startswith('libc.musl')]) != 0:
         # Need to compile libwebp if musllinux
-        build_mode = '*'
-    else:
-        build_mode = 'missing'
+        build.append('libwebp')
+    if not platform.machine().lower().startswith(('amd64', 'x86_64', 'x64', 'arm64', 'aarch64', 'armv8')):
+        build.append('cmake')
+    if build == []:
+        build.append('missing')
     
     subprocess.run(['conan', 'profile', 'detect'])
     result = subprocess.run([
-        'conan', 'install', *[x for s in settings for x in ('-s', s)], 
-        '-of', 'conan_output', '--deployer=full_deploy',
-        '--build', build_mode, '--format=json', '.'
+        'conan', 'install', 
+        *[x for s in settings for x in ('-s', s)],
+        *[x for b in build for x in ('-b', b)],
+        '-of', 'conan_output', '--deployer=full_deploy', '--format=json', '.'
         ], stdout=subprocess.PIPE).stdout.decode()
     # print(result)
     conan_info = json.loads(result)

--- a/webp_build/builder.py
+++ b/webp_build/builder.py
@@ -51,7 +51,7 @@ def fetch_cffi_settings(conan_info, cffi_settings):
         if dep.get('package_folder') == None:
             continue
         
-        for lib_name, i in reversed(dep['cpp_info']).items():
+        for lib_name, i in reversed(dep['cpp_info'].items()):
             for include_dir in dep['cpp_info'][lib_name].get('includedirs', []):
                 cffi_settings['include_dirs'].append(include_dir) if include_dir not in cffi_settings['include_dirs'] else None
 

--- a/webp_build/builder.py
+++ b/webp_build/builder.py
@@ -36,9 +36,8 @@ def install_libwebp(arch=None):
     result = subprocess.run(['conan', 'install', *settings, 
                              '-of', 'conan_output', '--deployer=full_deploy',
                              '--format=json', '.'], stdout=subprocess.PIPE).stdout.decode()
-    print(result)
+    # print(result)
     conan_info = json.loads(result)
-    # print(conan_info)
     
     return conan_info
 

--- a/webp_build/builder.py
+++ b/webp_build/builder.py
@@ -50,17 +50,12 @@ def fetch_cffi_settings(conan_info, cffi_settings):
     for dep in conan_info['graph']['nodes'].values():
         if dep.get('package_folder') == None:
             continue
-
-        for lib_name, i in dep['cpp_info'].items():
-            if lib_name == 'root':
-                continue
-            
-            for include_dir in i.get('includedirs', []):
+        
+        for lib_name, i in reversed(dep['cpp_info']).items():
+            for include_dir in dep['cpp_info'][lib_name].get('includedirs', []):
                 cffi_settings['include_dirs'].append(include_dir) if include_dir not in cffi_settings['include_dirs'] else None
 
-            lib_names = ['webpdecoder', 'webpdemux', 'webpmux', 'webp'] # DEBUG
-            # for lib_name in i.get('libs', []):
-            for lib_name in lib_names:
+            for lib_name in i.get('libs', []):
                 if platform.system() == 'Windows':
                     lib_filename = '{}.lib'.format(lib_name)
                 else:
@@ -70,8 +65,8 @@ def fetch_cffi_settings(conan_info, cffi_settings):
                     lib_path = os.path.join(lib_dir, lib_filename)
                     if os.path.isfile(lib_path):
                         cffi_settings['extra_objects'].append(lib_path)
-                    # else:
-                    #     cffi_settings['libraries'].append(lib_name)
+                    else:
+                        cffi_settings['libraries'].append(lib_name)
     
     if platform.system() == 'Darwin':
         cffi_settings['extra_compile_args'].append('-mmacosx-version-min=11.0')

--- a/webp_build/builder.py
+++ b/webp_build/builder.py
@@ -10,7 +10,7 @@ from cffi import FFI
 
 import webp_build
 
-PYWEBP_COMPILE_TARGET = os.getenv('PYWEBP_COMPILE_TARGET')
+
 conan_archs = {
     'x86_64': ['amd64', 'x86_64', 'x64'],
     'x86': ['i386', 'i686', 'x86'],
@@ -21,8 +21,9 @@ conan_archs = {
 
 def get_arch():
     arch = None
-    if PYWEBP_COMPILE_TARGET:
-        arch = PYWEBP_COMPILE_TARGET
+
+    if os.getenv('PYWEBP_COMPILE_TARGET'):
+        arch = os.getenv('PYWEBP_COMPILE_TARGET')
     elif platform.architecture()[0] == '32bit' and platform.machine().lower() in conan_archs['x86'] + conan_archs['x86_64']:
         arch = 'x86'
     else:
@@ -119,14 +120,14 @@ cffi_settings = {
 }
 
 arch = get_arch()
+print(f'Detected system architecture as {arch}')
 if platform.system() == 'Darwin':
     if arch == 'x86_64':
         cffi_settings['extra_compile_args'].append('-mmacosx-version-min=10.9')
     else:
         cffi_settings['extra_compile_args'].append('-mmacosx-version-min=11.0')
 
-
-if PYWEBP_COMPILE_TARGET == 'universal2':
+if arch == 'universal2':
     conan_info = install_libwebp('x86_64')
     cffi_settings = fetch_cffi_settings(conan_info, cffi_settings)
     conan_info = install_libwebp('armv8')


### PR DESCRIPTION
Use conan2 to build package. This would solve:
- Support for musllinux: https://github.com/anibali/pywebp/issues/15
- Support for python 3.12: https://github.com/anibali/pywebp/issues/47

This PR also includes adding support for building universal2 wheel, hence if you merge this, you need not merge https://github.com/anibali/pywebp/pull/50

I am not sure if conda-lock.yml, environment.yml, pdm.lock are needed or being used, please review.

This package itself is ready for python3.12 once this is merged (https://github.com/laggykiller/pywebp/actions/runs/6127196467/job/16632620714#step:4:1940), but I intentionally disable building python 3.12 wheel. It might be a good idea to wait for the following before enabling python3.12 wheel building:
- cffi releases 3.12 wheel
  - https://foss.heptapod.net/pypy/cffi/-/issues/571
  - https://github.com/laggykiller/pywebp/actions/runs/6108777395/job/16578506477#step:5:1153
  - Alternative solution 1:  `yum install -y libffi-devel` and `apk install libffi-dev` in `CIBW_BEFORE_ALL`
  - Alternative solution 2: Add libcffi as conan dependency: https://conan.io/center/recipes/libffi
- numpy releases 3.12 wheel
  - Unable to build numpy in virtualenv created by pytest, causing test to fail: https://github.com/laggykiller/pywebp/actions/runs/6127196467/job/16632620714#step:4:1995
  - numpy 1.26.0rc1 has 3.12 wheel, but not for stable version: https://pypi.org/project/numpy/1.26.0rc1/#files