### PR TITLE
Enable python 3.12 wheel building

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -148,7 +148,7 @@ jobs:
           # 3.12 will be ready when:
           # - cffi releases a 3.12 wheel
           # - numpy releases a 3.12 wheel
-          CIBW_PROJECT_REQUIRES_PYTHON: '>=3.8,<3.12'
+          CIBW_PROJECT_REQUIRES_PYTHON: '>=3.8'
           CIBW_TEST_REQUIRES: pytest
           CIBW_TEST_COMMAND: pytest {package}/tests
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -145,9 +145,6 @@ jobs:
           CIBW_ENVIRONMENT: PYWEBP_COMPILE_TARGET=${{ matrix.compile_target }}
           # TODO: Use arm64 CI runner when available
           CIBW_TEST_SKIP: "*_arm64"
-          # 3.12 will be ready when:
-          # - cffi releases a 3.12 wheel
-          # - numpy releases a 3.12 wheel
           CIBW_PROJECT_REQUIRES_PYTHON: '>=3.8'
           CIBW_TEST_REQUIRES: pytest
           CIBW_TEST_COMMAND: pytest {package}/tests


### PR DESCRIPTION
Good news, cffi and numpy released python 3.12 wheel, so we can build pywebp python 3.12 wheel now