### PR TITLE
Fix use-after-free in WebPAnimDecoder

### DIFF
--- a/tests/test_webp.py
+++ b/tests/test_webp.py
@@ -1,3 +1,5 @@
+import gc
+import weakref
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
@@ -236,3 +238,17 @@ class TestWebP:
         with pytest.raises(webp.WebPError) as ex_info:
             webp.WebPPicture.from_numpy(np.ones([2, 2, 2, 2], dtype=np.uint8))
         assert str(ex_info.value) == "unexpected array shape: (2, 2, 2, 2)"
+
+    def test_anim_decoder_keeps_webp_data_alive(self) -> None:
+        enc = webp.WebPAnimEncoder.new(8, 8)
+        enc.encode_frame(webp.WebPPicture.from_pil(Image.new("RGBA", (8, 8))), 0)
+        anim_bytes = bytes(enc.assemble(250).buffer())
+
+        webp_data = webp.WebPData.from_buffer(anim_bytes)
+        ref = weakref.ref(webp_data)
+        dec = webp.WebPAnimDecoder.new(webp_data)
+        del webp_data
+        gc.collect()
+
+        assert ref() is not None
+        assert dec.anim_info.frame_count == 1

--- a/webp/__init__.py
+++ b/webp/__init__.py
@@ -614,11 +614,16 @@ class WebPAnimInfo:
 class WebPAnimDecoder:
     """Decode animated WebP images."""
 
-    def __init__(self, ptr: _Pointer, dec_opts: WebPAnimDecoderOptions, anim_info: WebPAnimInfo) -> None:
+    def __init__(
+        self, ptr: _Pointer, dec_opts: WebPAnimDecoderOptions, anim_info: WebPAnimInfo, webp_data: WebPData
+    ) -> None:
         """Initialize the wrapper."""
         self.ptr = ptr
         self.dec_opts = dec_opts
         self.anim_info = anim_info
+        # Never read. Held so the bitstream outlives the decoder, which reads from it
+        # without copying.
+        self._webp_data = webp_data
 
     def __del__(self) -> None:
         """Release owned WebP resources."""
@@ -673,7 +678,7 @@ class WebPAnimDecoder:
         if lib.WebPAnimDecoderGetInfo(ptr, anim_info.ptr) == 0:
             msg = "failed to get animation info"
             raise WebPError(msg)
-        return WebPAnimDecoder(ptr, dec_opts, anim_info)
+        return WebPAnimDecoder(ptr, dec_opts, anim_info, webp_data)
 
 
 def imwrite(


### PR DESCRIPTION
## Changes

- Store the `WebPData` on `WebPAnimDecoder` so the bitstream outlives the decoder, which reads from it without copying
- Add a regression test that pins the reference chain with a weak reference, so it fails deterministically instead of segfaulting intermittently

Closes https://github.com/anibali/pywebp/issues/70
